### PR TITLE
Fix wrong resource reference

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -50,7 +50,7 @@ resource "talos_machine_configuration_apply" "cp_config_apply" {
 
 resource "talos_machine_configuration_apply" "worker_config_apply" {
   talos_config          = talos_client_configuration.talosconfig.talos_config
-  machine_configuration = talos_machine_configuration_controlplane.machineconfig_worker.machine_config
+  machine_configuration = talos_machine_configuration_worker.machineconfig_worker.machine_config
   config_patches = [
     file("${path.module}/files/worker.yaml"),
   ]


### PR DESCRIPTION
The example references the controlplane configuration for both the control plane and the worker nodes. This fixes that wrong reference.