### PR TITLE
fix: "tls: bad certificate" due to missing client cert

### DIFF
--- a/talos/util.go
+++ b/talos/util.go
@@ -6,7 +6,6 @@ package talos
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"strings"
 
@@ -236,9 +235,7 @@ func talosClientOp(ctx context.Context, endpoint, node, tc string, opFunc func(c
 		client.WithEndpoints([]string{endpoint}...),
 	}
 
-	c, err := client.New(ctx, append(clientOpts, client.WithTLSConfig(&tls.Config{
-		InsecureSkipVerify: true,
-	}))...)
+	c, err := client.New(ctx, clientOpts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When the terraform provider constructs its talos client in talosClientOp() it does so while appending a wither to set InsecureSkipVeriy on the tlsConfig. Unfortunately, the wither is executed before the rest of the tls config is constructed, leading to Client.options.tlsConfig to be empty except for InsecureSkipVerify=true.

By the time Client.getConn() is called to establish the grpc connection to the node, this non-nill tlsConfig leads to an early return in the method:
https://github.com/siderolabs/talos/blob/v1.2.7/pkg/machinery/client/connection.go#L56 before the client and ca certs could be loaded from the talosconfig, which normally happens in line 87:
https://github.com/siderolabs/talos/blob/v1.2.7/pkg/machinery/client/connection.go#L87 As a result, we try to establish a connection without client credentials which gets rejected by the server and results in the vague error "tls: bad certificate" from the grpc library.

This commit removes the InsecureSkipVerify wither, which is seemingly unecessary, since the grpc connection loads the ca cert from the talosconfig, allowing us to establish a fully secure connection.

P.S.: In the long run if overriding partial tlsConfig options is desirable, a change in machinery should likely be made to merge creds and/or delay evaluation of the withers, however for the use case of the provider setting InsecureSkipVerify seems unnecessary, so restoring functionality in the short run is preferable to waiting for a long term improvement in the deeper bowels fo the talos machinery.


Change was tested locally both using `make testacc` as well as running the provider with `--debug` and attaching terraform running a real-world IaC example from a PoC at work