### PR TITLE
fix: force new talosconfig if endpoints or nodes change

### DIFF
--- a/talos/resource_talos_client_configuration.go
+++ b/talos/resource_talos_client_configuration.go
@@ -43,6 +43,7 @@ func resourceTalosClientConfiguration() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				ForceNew: true,
 			},
 			"endpoints": {
 				Type:        schema.TypeList,
@@ -51,6 +52,7 @@ func resourceTalosClientConfiguration() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				ForceNew: true,
 			},
 			"talos_config": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
This PR fixes a bug where terraform was unable to apply when the number of control plane nodes was scaled from, for example, 1 to 3. This ensures that the talosconfig resource gets recreated any time the IPs in the list of endpoints or nodes is changed and that gets bubbled out to all of the other dependent objects. Seems to work well, tested with DO example.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>