### PR TITLE
chore: ci cleanup

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -1,6 +1,10 @@
-name: ci
+name: acceptance-tests
 on:
   pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - '**.go'
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -8,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -16,9 +20,6 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
-      - name: dirty-check
-        run: |
-          make check-dirty
       - name: Set up libvirt
         run: |
           sudo apt-get update

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,21 @@
+name: check-dirty
+on:
+  pull_request:
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
+      - name: dirty-check
+        run: |
+          make check-dirty

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -5,13 +5,19 @@ project_name = "terraform-provider-talos"
 github_repo = "siderolabs/terraform-provider-talos"
 match_deps = "^github.com/(siderolabs/[a-zA-Z0-9-]+)$"
 
-previous = "v0.1.0-beta.0"
+previous = "v0.1.2"
 pre_release = true
 
 [notes]
 
+    [notes.provider]
+        title = "Provider Changes"
+        description = """\
+This version of the provider includes some breaking changes. Make sure to follow the provider upgrade guide at https://registry.terraform.io/providers/siderolabs/talos/latest/docs/guides/version-0.2-upgrade
+"""
+
     [notes.updates]
         title = "Component Updates"
         description = """\
-Talos sdk: v1.3.1
+Talos sdk: v1.4.0-beta.0
 """


### PR DESCRIPTION
Run acceptance tests only on provider file changes. Only run the basic checks on PR's.