### PR TITLE
machine_configuration_apply: fix input argument

### DIFF
--- a/docs/resources/machine_configuration_apply.md
+++ b/docs/resources/machine_configuration_apply.md
@@ -28,9 +28,9 @@ data "talos_client_configuration" "this" {
 }
 
 resource "talos_machine_configuration_apply" "this" {
-  client_configuration  = talos_machine_secrets.this.client_configuration
-  machine_configuration = data.talos_machine_configuration.this.machine_configuration
-  node                  = "10.5.0.2"
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.this.machine_configuration
+  node                        = "10.5.0.2"
   config_patches = [
     yamlencode({
       machine = {


### PR DESCRIPTION
This is called `machine_configuration_input`, not `machine_configuration`, as can be seen in the schema below.