### PR TITLE
docs: replace `type` with `machine_type`

### DIFF
--- a/docs/data-sources/cluster_kubeconfig.md
+++ b/docs/data-sources/cluster_kubeconfig.md
@@ -17,7 +17,7 @@ resource "talos_machine_secrets" "this" {}
 
 data "talos_machine_configuration" "this" {
   cluster_name     = "example-cluster"
-  type             = "controlplane"
+  machine_type     = "controlplane"
   cluster_endpoint = "https://cluster.local:6443"
   machine_secrets  = talos_machine_secrets.this.machine_secrets
 }
@@ -29,9 +29,9 @@ data "talos_client_configuration" "this" {
 }
 
 resource "talos_machine_configuration_apply" "this" {
-  client_configuration  = talos_machine_secrets.this.client_configuration
-  machine_configuration = data.talos_machine_configuration.this.machine_configuration
-  node                  = "10.5.0.2"
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.this.machine_configuration
+  node                        = "10.5.0.2"
   config_patches = [
     yamlencode({
       machine = {

--- a/docs/data-sources/machine_configuration.md
+++ b/docs/data-sources/machine_configuration.md
@@ -18,7 +18,7 @@ resource "talos_machine_secrets" "this" {}
 
 data "talos_machine_configuration" "this" {
   cluster_name     = "example-cluster"
-  type             = "controlplane"
+  machine_type     = "controlplane"
   cluster_endpoint = "https://cluster.local:6443"
   machine_secrets  = talos_machine_secrets.this.machine_secrets
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ Talos provider allows to generate configs for a Talos cluster and apply them to 
 Complete usages for this provider can be found at:
 
 - [AWS](https://github.com/siderolabs/contrib/tree/main/examples/terraform/aws)
+- [Advanced](https://github.com/siderolabs/contrib/tree/main/examples/terraform/advanced)
+- [Azure](https://github.com/siderolabs/contrib/tree/main/examples/terraform/azure)
 - [Basic](https://github.com/siderolabs/contrib/tree/main/examples/terraform/basic)
 - [Equinix Metal](https://github.com/siderolabs/contrib/tree/main/examples/terraform/equinix-metal)
 - [Hetzner Cloud](https://github.com/siderolabs/contrib/tree/main/examples/terraform/hcloud)

--- a/docs/resources/machine_bootstrap.md
+++ b/docs/resources/machine_bootstrap.md
@@ -16,7 +16,7 @@ resource "talos_machine_secrets" "this" {}
 
 data "talos_machine_configuration" "this" {
   cluster_name     = "example-cluster"
-  type             = "controlplane"
+  machine_type     = "controlplane"
   cluster_endpoint = "https://cluster.local:6443"
   machine_secrets  = talos_machine_secrets.this.machine_secrets
 }
@@ -28,9 +28,9 @@ data "talos_client_configuration" "this" {
 }
 
 resource "talos_machine_configuration_apply" "this" {
-  client_configuration  = talos_machine_secrets.this.client_configuration
-  machine_configuration = data.talos_machine_configuration.this.machine_configuration
-  node                  = "10.5.0.2"
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.this.machine_configuration
+  node                        = "10.5.0.2"
   config_patches = [
     yamlencode({
       machine = {

--- a/docs/resources/machine_configuration_apply.md
+++ b/docs/resources/machine_configuration_apply.md
@@ -16,7 +16,7 @@ resource "talos_machine_secrets" "this" {}
 
 data "talos_machine_configuration" "this" {
   cluster_name     = "example-cluster"
-  type             = "controlplane"
+  machine_type     = "controlplane"
   cluster_endpoint = "https://cluster.local:6443"
   machine_secrets  = talos_machine_secrets.this.machine_secrets
 }

--- a/examples/data-sources/talos_cluster_kubeconfig/data-source.tf
+++ b/examples/data-sources/talos_cluster_kubeconfig/data-source.tf
@@ -2,7 +2,7 @@ resource "talos_machine_secrets" "this" {}
 
 data "talos_machine_configuration" "this" {
   cluster_name     = "example-cluster"
-  type             = "controlplane"
+  machine_type     = "controlplane"
   cluster_endpoint = "https://cluster.local:6443"
   machine_secrets  = talos_machine_secrets.this.machine_secrets
 }
@@ -14,9 +14,9 @@ data "talos_client_configuration" "this" {
 }
 
 resource "talos_machine_configuration_apply" "this" {
-  client_configuration  = talos_machine_secrets.this.client_configuration
-  machine_configuration = data.talos_machine_configuration.this.machine_configuration
-  node                  = "10.5.0.2"
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.this.machine_configuration
+  node                        = "10.5.0.2"
   config_patches = [
     yamlencode({
       machine = {

--- a/examples/data-sources/talos_machine_configuration/data-source.tf
+++ b/examples/data-sources/talos_machine_configuration/data-source.tf
@@ -2,7 +2,7 @@ resource "talos_machine_secrets" "this" {}
 
 data "talos_machine_configuration" "this" {
   cluster_name     = "example-cluster"
-  type             = "controlplane"
+  machine_type     = "controlplane"
   cluster_endpoint = "https://cluster.local:6443"
   machine_secrets  = talos_machine_secrets.this.machine_secrets
 }

--- a/examples/resources/talos_machine_bootstrap/resource.tf
+++ b/examples/resources/talos_machine_bootstrap/resource.tf
@@ -2,7 +2,7 @@ resource "talos_machine_secrets" "this" {}
 
 data "talos_machine_configuration" "this" {
   cluster_name     = "example-cluster"
-  type             = "controlplane"
+  machine_type     = "controlplane"
   cluster_endpoint = "https://cluster.local:6443"
   machine_secrets  = talos_machine_secrets.this.machine_secrets
 }
@@ -14,9 +14,9 @@ data "talos_client_configuration" "this" {
 }
 
 resource "talos_machine_configuration_apply" "this" {
-  client_configuration  = talos_machine_secrets.this.client_configuration
-  machine_configuration = data.talos_machine_configuration.this.machine_configuration
-  node                  = "10.5.0.2"
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.this.machine_configuration
+  node                        = "10.5.0.2"
   config_patches = [
     yamlencode({
       machine = {

--- a/examples/resources/talos_machine_configuration_apply/resource.tf
+++ b/examples/resources/talos_machine_configuration_apply/resource.tf
@@ -2,7 +2,7 @@ resource "talos_machine_secrets" "this" {}
 
 data "talos_machine_configuration" "this" {
   cluster_name     = "example-cluster"
-  type             = "controlplane"
+  machine_type     = "controlplane"
   cluster_endpoint = "https://cluster.local:6443"
   machine_secrets  = talos_machine_secrets.this.machine_secrets
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -11,6 +11,8 @@ Talos provider allows to generate configs for a Talos cluster and apply them to 
 Complete usages for this provider can be found at:
 
 - [AWS](https://github.com/siderolabs/contrib/tree/main/examples/terraform/aws)
+- [Advanced](https://github.com/siderolabs/contrib/tree/main/examples/terraform/advanced)
+- [Azure](https://github.com/siderolabs/contrib/tree/main/examples/terraform/azure)
 - [Basic](https://github.com/siderolabs/contrib/tree/main/examples/terraform/basic)
 - [Equinix Metal](https://github.com/siderolabs/contrib/tree/main/examples/terraform/equinix-metal)
 - [Hetzner Cloud](https://github.com/siderolabs/contrib/tree/main/examples/terraform/hcloud)


### PR DESCRIPTION
When experimenting with the provider, it failed on the examples given in the documentation because it was using `type` instead of `machine_type`