### PR TITLE
docs: update link to contrib repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,12 +8,4 @@ description: |-
 
 Talos provider allows to generate configs for a Talos cluster and apply them to the nodes, bootstrap nodes and retrieve `kubeconfig` and `talosconfig`.
 
-Complete usages for this provider can be found at:
-
-- [AWS](https://github.com/siderolabs/contrib/tree/main/examples/terraform/aws)
-- [Advanced](https://github.com/siderolabs/contrib/tree/main/examples/terraform/advanced)
-- [Azure](https://github.com/siderolabs/contrib/tree/main/examples/terraform/azure)
-- [Basic](https://github.com/siderolabs/contrib/tree/main/examples/terraform/basic)
-- [Equinix Metal](https://github.com/siderolabs/contrib/tree/main/examples/terraform/equinix-metal)
-- [Hetzner Cloud](https://github.com/siderolabs/contrib/tree/main/examples/terraform/hcloud)
-- [Vultr](https://github.com/siderolabs/contrib/tree/main/examples/terraform/vultr)
+Complete usages for this provider across a variety of enviroments can be found [here](https://github.com/siderolabs/contrib/tree/main/examples/terraform).

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -8,12 +8,4 @@ description: |-
 
 Talos provider allows to generate configs for a Talos cluster and apply them to the nodes, bootstrap nodes and retrieve `kubeconfig` and `talosconfig`.
 
-Complete usages for this provider can be found at:
-
-- [AWS](https://github.com/siderolabs/contrib/tree/main/examples/terraform/aws)
-- [Advanced](https://github.com/siderolabs/contrib/tree/main/examples/terraform/advanced)
-- [Azure](https://github.com/siderolabs/contrib/tree/main/examples/terraform/azure)
-- [Basic](https://github.com/siderolabs/contrib/tree/main/examples/terraform/basic)
-- [Equinix Metal](https://github.com/siderolabs/contrib/tree/main/examples/terraform/equinix-metal)
-- [Hetzner Cloud](https://github.com/siderolabs/contrib/tree/main/examples/terraform/hcloud)
-- [Vultr](https://github.com/siderolabs/contrib/tree/main/examples/terraform/vultr)
+Complete usages for this provider across a variety of enviroments can be found [here](https://github.com/siderolabs/contrib/tree/main/examples/terraform).


### PR DESCRIPTION
This PR updates the link in our terraform provider docs to point to the contrib repo's terraform/ directory instead of calling out each environment one by one.