### PR TITLE
fix: node/endpoint were swapped for some resources.

### DIFF
--- a/internal/talos/talos_cluster_kubeconfig_data_source.go
+++ b/internal/talos/talos_cluster_kubeconfig_data_source.go
@@ -181,8 +181,8 @@ func (d *talosClusterKubeConfigDataSource) Read(ctx context.Context, req datasou
 	defer cancel()
 
 	if retryErr := retry.RetryContext(ctxDeadline, readTimeout, func() *retry.RetryError {
-		if clientOpErr := talosClientOp(ctx, state.Node.ValueString(), state.Endpoint.ValueString(), talosConfig, func(opFuncCtx context.Context, c *client.Client) error {
-			kubeConfigBytes, clientErr := c.Kubeconfig(opFuncCtx)
+		if clientOpErr := talosClientOp(ctx, state.Endpoint.ValueString(), state.Node.ValueString(), talosConfig, func(nodeCtx context.Context, c *client.Client) error {
+			kubeConfigBytes, clientErr := c.Kubeconfig(nodeCtx)
 			if clientErr != nil {
 				return clientErr
 			}

--- a/internal/talos/talos_machine_bootstrap_resource.go
+++ b/internal/talos/talos_machine_bootstrap_resource.go
@@ -140,8 +140,8 @@ func (r *talosMachineBootstrapResource) Create(ctx context.Context, req resource
 	defer cancel()
 
 	if err := retry.RetryContext(ctxDeadline, createTimeout, func() *retry.RetryError {
-		if err := talosClientOp(ctx, state.Endpoint.ValueString(), state.Node.ValueString(), talosClientConfig, func(opFuncCtx context.Context, c *client.Client) error {
-			return c.Bootstrap(opFuncCtx, &machineapi.BootstrapRequest{})
+		if err := talosClientOp(ctx, state.Endpoint.ValueString(), state.Node.ValueString(), talosClientConfig, func(nodeCtx context.Context, c *client.Client) error {
+			return c.Bootstrap(nodeCtx, &machineapi.BootstrapRequest{})
 		}); err != nil {
 			if s := status.Code(err); s == codes.InvalidArgument {
 				return retry.NonRetryableError(err)

--- a/internal/talos/talos_machine_configuration_apply_resource.go
+++ b/internal/talos/talos_machine_configuration_apply_resource.go
@@ -175,8 +175,8 @@ func (p *talosMachineConfigurationApplyResource) Create(ctx context.Context, req
 	defer cancel()
 
 	if err := retry.RetryContext(ctxDeadline, createTimeout, func() *retry.RetryError {
-		if err := talosClientOp(ctx, state.Endpoint.ValueString(), state.Node.ValueString(), talosClientConfig, func(opFuncCtx context.Context, c *client.Client) error {
-			_, err := c.ApplyConfiguration(opFuncCtx, &machineapi.ApplyConfigurationRequest{
+		if err := talosClientOp(ctx, state.Endpoint.ValueString(), state.Node.ValueString(), talosClientConfig, func(nodeCtx context.Context, c *client.Client) error {
+			_, err := c.ApplyConfiguration(nodeCtx, &machineapi.ApplyConfigurationRequest{
 				Mode: machineapi.ApplyConfigurationRequest_Mode(machineapi.ApplyConfigurationRequest_Mode_value[strings.ToUpper(state.ApplyMode.ValueString())]),
 				Data: []byte(state.MachineConfiguration.ValueString()),
 			})
@@ -253,8 +253,8 @@ func (p *talosMachineConfigurationApplyResource) Update(ctx context.Context, req
 	defer cancel()
 
 	if err := retry.RetryContext(ctxDeadline, updateTimeout, func() *retry.RetryError {
-		if err := talosClientOp(ctx, state.Endpoint.ValueString(), state.Node.ValueString(), talosClientConfig, func(opFuncCtx context.Context, c *client.Client) error {
-			_, err := c.ApplyConfiguration(opFuncCtx, &machineapi.ApplyConfigurationRequest{
+		if err := talosClientOp(ctx, state.Endpoint.ValueString(), state.Node.ValueString(), talosClientConfig, func(nodeCtx context.Context, c *client.Client) error {
+			_, err := c.ApplyConfiguration(nodeCtx, &machineapi.ApplyConfigurationRequest{
 				Mode: machineapi.ApplyConfigurationRequest_Mode(machineapi.ApplyConfigurationRequest_Mode_value[strings.ToUpper(state.ApplyMode.ValueString())]),
 				Data: []byte(state.MachineConfiguration.ValueString()),
 			})

--- a/internal/talos/talos_machine_disks_data_source.go
+++ b/internal/talos/talos_machine_disks_data_source.go
@@ -339,8 +339,8 @@ func (d *talosMachineDisksDataSource) Read(ctx context.Context, req datasource.R
 	}
 
 	if err := retry.RetryContext(ctxDeadline, readTimeout, func() *retry.RetryError {
-		if err := talosClientOp(ctx, state.Node.ValueString(), state.Endpoint.ValueString(), talosConfig, func(opFuncCtx context.Context, c *client.Client) error {
-			diskResp, err := c.Disks(opFuncCtx)
+		if err := talosClientOp(ctx, state.Endpoint.ValueString(), state.Node.ValueString(), talosConfig, func(nodeCtx context.Context, c *client.Client) error {
+			diskResp, err := c.Disks(nodeCtx)
 			if err != nil {
 				return err
 			}

--- a/internal/talos/util.go
+++ b/internal/talos/util.go
@@ -203,7 +203,7 @@ func validateVersionContract(version string) (*config.VersionContract, error) {
 }
 
 func talosClientOp(ctx context.Context, endpoint, node string, tc *clientconfig.Config, opFunc func(ctx context.Context, c *client.Client) error) error {
-	opCtx := client.WithNode(ctx, node)
+	nodeCtx := client.WithNode(ctx, node)
 
 	c, err := client.New(ctx, client.WithTLSConfig(&tls.Config{
 		InsecureSkipVerify: true,
@@ -212,7 +212,7 @@ func talosClientOp(ctx context.Context, endpoint, node string, tc *clientconfig.
 		return err
 	}
 
-	_, err = c.Disks(opCtx)
+	_, err = c.Disks(nodeCtx)
 	if err != nil {
 		c.Close() //nolint:errcheck
 
@@ -223,7 +223,7 @@ func talosClientOp(ctx context.Context, endpoint, node string, tc *clientconfig.
 	}
 	defer c.Close() //nolint:errcheck
 
-	return opFunc(opCtx, c)
+	return opFunc(nodeCtx, c)
 }
 
 type talosVersionValidator struct{}


### PR DESCRIPTION
Fix node and endpoint being swapped for `kubeconfig` and `disks` data sources.

Fixes: #98

Signed-off-by: Noel Georgi <git@frezbo.dev>
(cherry picked from commit 5ac7183f33a425e17821f1a294a3133daa09e7fa)