### PR TITLE
docs: correct talos_client_configuration nodes parameter in examples

### DIFF
--- a/docs/data-sources/cluster_kubeconfig.md
+++ b/docs/data-sources/cluster_kubeconfig.md
@@ -71,7 +71,7 @@ data "talos_cluster_kubeconfig" "this" {
 
 ### Optional
 
-- `endpoint` (String) endpoint to use for the talosclient. if not set, the node value will be used
+- `endpoint` (String) endpoint to use for the talosclient. If not set, the node value will be used
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `wait` (Boolean, Deprecated) Wait for the kubernetes api to be available
 

--- a/docs/data-sources/machine_disks.md
+++ b/docs/data-sources/machine_disks.md
@@ -25,7 +25,7 @@ data "talos_machine_disks" "this" {
   }
 }
 
-# for example this could be used to pass in list of disks to rook-ceph
+# for example, this could be used to pass in a list of disks to rook-ceph
 output "nvme_disks" {
   value = data.talos_machine_disks.this.disks.*.name
 }
@@ -40,7 +40,7 @@ output "nvme_disks" {
 
 ### Optional
 
-- `endpoint` (String) endpoint to use for the talosclient. if not set, the node value will be used
+- `endpoint` (String) endpoint to use for the talosclient. If not set, the node value will be used
 - `filters` (Attributes) Filters to apply to the disks (see [below for nested schema](#nestedatt--filters))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 ---
 page_title: "Provider: Talos"
 description: |-
-  The Talos provider is used manage a Talos cluster config generation and initial setup.
+  The Talos provider is used to manage a Talos cluster config generation and initial setup.
 ---
 
 # Talos Provider
 
-Talos provider allows to generate configs for a Talos cluster and apply them to the nodes, bootstrap nodes and retrieve `kubeconfig` and `talosconfig`.
+Talos provider allows to generate configs for a Talos cluster and apply them to the nodes, bootstrap nodes, check cluster health, and retrieve `kubeconfig` and `talosconfig`.
 
-Complete usages for this provider across a variety of enviroments can be found [here](https://github.com/siderolabs/contrib/tree/main/examples/terraform).
+Complete usages for this provider across a variety of environments can be found [here](https://github.com/siderolabs/contrib/tree/main/examples/terraform).

--- a/docs/resources/machine_bootstrap.md
+++ b/docs/resources/machine_bootstrap.md
@@ -24,7 +24,7 @@ data "talos_machine_configuration" "this" {
 data "talos_client_configuration" "this" {
   cluster_name         = "example-cluster"
   client_configuration = talos_machine_secrets.this.client_configuration
-  node                 = ["10.5.0.2"]
+  nodes                = ["10.5.0.2"]
 }
 
 resource "talos_machine_configuration_apply" "this" {

--- a/docs/resources/machine_configuration_apply.md
+++ b/docs/resources/machine_configuration_apply.md
@@ -24,7 +24,7 @@ data "talos_machine_configuration" "this" {
 data "talos_client_configuration" "this" {
   cluster_name         = "example-cluster"
   client_configuration = talos_machine_secrets.this.client_configuration
-  node                 = ["10.5.0.2"]
+  nodes                = ["10.5.0.2"]
 }
 
 resource "talos_machine_configuration_apply" "this" {

--- a/examples/data-sources/talos_machine_disks/data-source.tf
+++ b/examples/data-sources/talos_machine_disks/data-source.tf
@@ -9,7 +9,7 @@ data "talos_machine_disks" "this" {
   }
 }
 
-# for example this could be used to pass in list of disks to rook-ceph
+# for example, this could be used to pass in a list of disks to rook-ceph
 output "nvme_disks" {
   value = data.talos_machine_disks.this.disks.*.name
 }

--- a/examples/resources/talos_machine_bootstrap/resource.tf
+++ b/examples/resources/talos_machine_bootstrap/resource.tf
@@ -10,7 +10,7 @@ data "talos_machine_configuration" "this" {
 data "talos_client_configuration" "this" {
   cluster_name         = "example-cluster"
   client_configuration = talos_machine_secrets.this.client_configuration
-  node                 = ["10.5.0.2"]
+  nodes                = ["10.5.0.2"]
 }
 
 resource "talos_machine_configuration_apply" "this" {

--- a/examples/resources/talos_machine_configuration_apply/resource.tf
+++ b/examples/resources/talos_machine_configuration_apply/resource.tf
@@ -10,7 +10,7 @@ data "talos_machine_configuration" "this" {
 data "talos_client_configuration" "this" {
   cluster_name         = "example-cluster"
   client_configuration = talos_machine_secrets.this.client_configuration
-  node                 = ["10.5.0.2"]
+  nodes                = ["10.5.0.2"]
 }
 
 resource "talos_machine_configuration_apply" "this" {

--- a/internal/talos/talos_cluster_kubeconfig_data_source.go
+++ b/internal/talos/talos_cluster_kubeconfig_data_source.go
@@ -65,7 +65,7 @@ func (d *talosClusterKubeConfigDataSource) Schema(ctx context.Context, _ datasou
 			"endpoint": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "endpoint to use for the talosclient. if not set, the node value will be used",
+				Description: "endpoint to use for the talosclient. If not set, the node value will be used",
 			},
 			"client_configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{

--- a/internal/talos/talos_machine_disks_data_source.go
+++ b/internal/talos/talos_machine_disks_data_source.go
@@ -125,7 +125,7 @@ func (d *talosMachineDisksDataSource) Schema(ctx context.Context, _ datasource.S
 			"endpoint": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "endpoint to use for the talosclient. if not set, the node value will be used",
+				Description: "endpoint to use for the talosclient. If not set, the node value will be used",
 			},
 			"client_configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,11 +1,11 @@
 ---
 page_title: "Provider: Talos"
 description: |-
-  The Talos provider is used manage a Talos cluster config generation and initial setup.
+  The Talos provider is used to manage a Talos cluster config generation and initial setup.
 ---
 
 # Talos Provider
 
-Talos provider allows to generate configs for a Talos cluster and apply them to the nodes, bootstrap nodes and retrieve `kubeconfig` and `talosconfig`.
+Talos provider allows to generate configs for a Talos cluster and apply them to the nodes, bootstrap nodes, check cluster health, and retrieve `kubeconfig` and `talosconfig`.
 
-Complete usages for this provider across a variety of enviroments can be found [here](https://github.com/siderolabs/contrib/tree/main/examples/terraform).
+Complete usages for this provider across a variety of environments can be found [here](https://github.com/siderolabs/contrib/tree/main/examples/terraform).


### PR DESCRIPTION
This PR fixes a few random typos I found while perusing the documentation. `docs/resources/machine_bootstrap.md` and `docs/resources/machine_configuration_apply.md` both had an incorrect parameter shown in `talos_client_configuration` and should be `nodes` rather than `node` as shown here `internal/talos/talos_client_configuration_data_source.go#L25`