### PR TITLE
fix talos_version nil parsing

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -1,4 +1,7 @@
 name: acceptance-tests
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:
@@ -7,7 +10,9 @@ on:
       - '**.go'
 jobs:
   acc-tests:
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - generic
     env:
       GOTOOLCHAIN: local
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -3,7 +3,9 @@ on:
   pull_request:
 jobs:
   check-dirty:
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - generic
     env:
       GOTOOLCHAIN: local
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ permissions:
   contents: write
 jobs:
   goreleaser:
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - generic
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Talos Terraform Provider",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            // this assumes your workspace is the root of the repo
+            "program": "${workspaceFolder}",
+            "env": {},
+            "args": [
+                "-debug",
+            ]
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ testacc:
 check-dirty: generate ## Verifies that source tree is not dirty
 	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; exit 1 ; fi
 
+build-debug:
+	go build -gcflags='all=-N -l'
+
 install:
 	go install .
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
 # terraform-provider-talos
 
-TODO: Validate after patching
-TODO: Ability to have variations of the baseline configuration (i.e. needing unique configuration files per machine)
+## Debugging
+
+In a bash shell, build a debug version of this provider binary:
+
+```bash
+make build-debug
+```
+
+In Visual Studio Code, [start the provider in a debug session](https://developer.hashicorp.com/terraform/plugin/debugging#starting-a-provider-in-debug-mode).
+
+In a new bash shell, go into your terraform project directory, and run
+terraform with `TF_REATTACH_PROVIDERS` set to the value printed in the VSCode debug windows.

--- a/internal/talos/talos_machine_configuration_data_source.go
+++ b/internal/talos/talos_machine_configuration_data_source.go
@@ -343,7 +343,7 @@ func (d talosMachineConfigurationDataSource) ValidateConfig(ctx context.Context,
 		return
 	}
 
-	if !state.KubernetesVersion.IsUnknown() && !state.KubernetesVersion.IsNull() {
+	if !state.KubernetesVersion.IsUnknown() && !state.KubernetesVersion.IsNull() && !state.TalosVersion.IsUnknown() {
 		k8sVersionCompatibility, err := compatibility.ParseKubernetesVersion(strings.TrimPrefix(state.KubernetesVersion.ValueString(), "v"))
 		if err != nil {
 			resp.Diagnostics.AddError(
@@ -354,18 +354,14 @@ func (d talosMachineConfigurationDataSource) ValidateConfig(ctx context.Context,
 			return
 		}
 
-		var talosVersionInfo *machineapi.VersionInfo
+		talosVersionInfo := &machineapi.VersionInfo{}
 
-		if !state.TalosVersion.IsUnknown() && state.TalosVersion.IsNull() {
-			talosVersionInfo = &machineapi.VersionInfo{
-				Tag: gendata.VersionTag,
-			}
+		if state.TalosVersion.IsNull() {
+			talosVersionInfo.Tag = gendata.VersionTag
 		}
 
-		if !state.TalosVersion.IsUnknown() && !state.TalosVersion.IsNull() {
-			talosVersionInfo = &machineapi.VersionInfo{
-				Tag: state.TalosVersion.ValueString(),
-			}
+		if !state.TalosVersion.IsNull() {
+			talosVersionInfo.Tag = state.TalosVersion.ValueString()
 		}
 
 		talosVersionCompatibility, err := compatibility.ParseTalosVersion(talosVersionInfo)

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -24,8 +25,14 @@ import (
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name talos
 
 func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	opts := providerserver.ServeOpts{
 		Address: "registry.terraform.io/siderolabs/talos",
+		Debug:   debug,
 	}
 
 	err := providerserver.Serve(context.Background(), talos.New, opts)


### PR DESCRIPTION
This fixes the talos_version parsing.

For some odd reason, while trying to use a terraform variable (please see the last commit at the branch at https://github.com/rgl/terraform-libvirt-talos/tree/wip-tfvars). this provider started to crash. This PR fixed that crash by now returning an "internal error" kind of message. But that still does not make my branch work!

Even thou this PR seems to be needed, I'm still stuck, I can now see this internal error, but I have no idea what I'm doing to trigger this in terraform.

PS: Oh, commenting the `kubernetes_version` property prevents the original crash from happening:

```yml
data "talos_machine_configuration" "controller" {
  cluster_name       = var.cluster_name
  cluster_endpoint   = local.cluster_endpoint
  machine_secrets    = talos_machine_secrets.talos.machine_secrets
  machine_type       = "controlplane"
  talos_version      = var.talos_version_tag
  #kubernetes_version = "1.26.8"
```

Is there a talos-version <-> k8s-version strict relationship? I thought I could use any version from https://github.com/siderolabs/kubelet/pkgs/container/kubelet