### PR TITLE
Default talos_machine_configuration docs and examples to false

### DIFF
--- a/docs/data-sources/machine_configuration.md
+++ b/docs/data-sources/machine_configuration.md
@@ -36,8 +36,8 @@ data "talos_machine_configuration" "this" {
 ### Optional
 
 - `config_patches` (List of String) The list of config patches to apply to the generated configuration
-- `docs` (Boolean) Whether to generate documentation for the generated configuration
-- `examples` (Boolean) Whether to generate examples for the generated configuration
+- `docs` (Boolean) Whether to generate documentation for the generated configuration. Defaults to false
+- `examples` (Boolean) Whether to generate examples for the generated configuration. DFaults to false
 - `kubernetes_version` (String) The version of kubernetes to use
 - `talos_version` (String) The version of talos features to use in generated machine configuration
 

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -35,6 +35,14 @@ The `talos_cluster_kubeconfig` resource will regenerate kubernetes client config
 `talos_machine_configuration_apply` resource now optionally supports resetting the machine back to maintenance mode.
 """
 
+    [notes.talos_machine_configuration]
+        title = "Talos Machine Configuration Data Source"
+        description = """\
+`talos_machine_configuration` data source now defaults to generating config with documentation and examples disabled.
+
+To restore the previous behavior, set `docs` and `examples` attributes to `true`.
+"""
+
     [notes.image-factory]
         title = "Image Factory"
         description = """\

--- a/pkg/talos/talos_machine_configuration_data_source.go
+++ b/pkg/talos/talos_machine_configuration_data_source.go
@@ -171,11 +171,11 @@ func (d *talosMachineConfigurationDataSource) Schema(_ context.Context, _ dataso
 				},
 			},
 			"docs": schema.BoolAttribute{
-				Description: "Whether to generate documentation for the generated configuration",
+				Description: "Whether to generate documentation for the generated configuration. Defaults to false",
 				Optional:    true,
 			},
 			"examples": schema.BoolAttribute{
-				Description: "Whether to generate examples for the generated configuration",
+				Description: "Whether to generate examples for the generated configuration. DFaults to false",
 				Optional:    true,
 			},
 			"machine_configuration": schema.StringAttribute{
@@ -195,15 +195,6 @@ func (d *talosMachineConfigurationDataSource) Read(ctx context.Context, req data
 
 	if resp.Diagnostics.HasError() {
 		return
-	}
-
-	// set default values
-	if !state.Docs.IsUnknown() && state.Docs.IsNull() {
-		state.Docs = basetypes.NewBoolValue(true)
-	}
-
-	if !state.Examples.IsUnknown() && state.Examples.IsNull() {
-		state.Examples = basetypes.NewBoolValue(true)
 	}
 
 	if !state.KubernetesVersion.IsUnknown() && state.KubernetesVersion.IsNull() {

--- a/pkg/talos/talos_machine_configuration_data_source_test.go
+++ b/pkg/talos/talos_machine_configuration_data_source_test.go
@@ -157,8 +157,8 @@ func TestAccTalosMachineConfigurationDataSource(t *testing.T) {
 							constants.DefaultKubernetesVersion,
 							"controlplane",
 							value,
-							true,
 							false,
+							true,
 							func(t *testing.T, config v1alpha1.Config) error {
 								assert.NotEmpty(t, config.Cluster().AESCBCEncryptionSecret())
 								assert.Empty(t, config.Cluster().SecretboxEncryptionSecret())
@@ -351,14 +351,18 @@ func validateGeneratedTalosMachineConfig(
 	if examples {
 		// verifying there's examples
 		assert.Contains(t, mc, (`
-        # diskSelector:
-        #     size: 4GB # Disk size.
+    #   # Uncomment this to enable SANs.
+    #   - 10.0.0.10
+    #   - 172.16.0.10
+    #   - 192.168.0.10
 `))
 	} else {
 		// verifying there's no examples
 		assert.NotContains(t, mc, (`
-	        # diskSelector:
-	        #     size: 4GB # Disk size.
+    #   # Uncomment this to enable SANs.
+    #   - 10.0.0.10
+    #   - 172.16.0.10
+    #   - 192.168.0.10
 `))
 	}
 


### PR DESCRIPTION
Generating talos machine configs with docs and examples enabled makes them too large. Fixes #181