### PR TITLE
fix: resourceplanmodifiers for kubeconfig resource

### DIFF
--- a/pkg/talos/talos_client_configuration_data_source.go
+++ b/pkg/talos/talos_client_configuration_data_source.go
@@ -146,7 +146,7 @@ func (d *talosClientConfigurationDataSource) Read(ctx context.Context, req datas
 	state.TalosConfig = basetypes.NewStringValue(string(talosConfigStringBytes))
 	state.ID = state.ClusterName
 
-	diags = resp.State.Set(ctx, state)
+	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {

--- a/pkg/talos/talos_cluster_health_data_source.go
+++ b/pkg/talos/talos_cluster_health_data_source.go
@@ -264,7 +264,7 @@ func (d *talosClusterHealthDataSource) Read(ctx context.Context, req datasource.
 
 	state.ID = basetypes.NewStringValue("cluster_health")
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/pkg/talos/talos_cluster_kubeconfig_data_source.go
+++ b/pkg/talos/talos_cluster_kubeconfig_data_source.go
@@ -214,7 +214,7 @@ func (d *talosClusterKubeConfigDataSource) Read(ctx context.Context, req datasou
 
 	state.ID = basetypes.NewStringValue(clusterName)
 
-	diags = resp.State.Set(ctx, state)
+	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {

--- a/pkg/talos/talos_cluster_kubeconfig_resource.go
+++ b/pkg/talos/talos_cluster_kubeconfig_resource.go
@@ -14,6 +14,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -63,6 +66,9 @@ func (r *talosClusterKubeConfigResource) Schema(ctx context.Context, _ resource.
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"node": schema.StringAttribute{
 				Required:    true,
@@ -96,6 +102,9 @@ func (r *talosClusterKubeConfigResource) Schema(ctx context.Context, _ resource.
 				Computed:    true,
 				Description: "The raw kubeconfig",
 				Sensitive:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"kubernetes_client_configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
@@ -119,6 +128,9 @@ func (r *talosClusterKubeConfigResource) Schema(ctx context.Context, _ resource.
 				},
 				Computed:    true,
 				Description: "The kubernetes client configuration",
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,
@@ -222,7 +234,7 @@ func (r *talosClusterKubeConfigResource) Create(ctx context.Context, req resourc
 
 	state.ID = basetypes.NewStringValue(clusterName)
 
-	diags = resp.State.Set(ctx, state)
+	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {

--- a/pkg/talos/talos_machine_bootstrap_resource.go
+++ b/pkg/talos/talos_machine_bootstrap_resource.go
@@ -307,7 +307,7 @@ func (r *talosMachineBootstrapResource) UpgradeState(_ context.Context) map[int6
 				}
 
 				// Set state to fully populated data
-				diags = resp.State.Set(ctx, state)
+				diags = resp.State.Set(ctx, &state)
 				resp.Diagnostics.Append(diags...)
 				if resp.Diagnostics.HasError() {
 					return

--- a/pkg/talos/talos_machine_configuration_apply_resource.go
+++ b/pkg/talos/talos_machine_configuration_apply_resource.go
@@ -621,7 +621,7 @@ func (p *talosMachineConfigurationApplyResource) UpgradeState(_ context.Context)
 				}
 
 				// Set state to fully populated data
-				diags = resp.State.Set(ctx, state)
+				diags = resp.State.Set(ctx, &state)
 				resp.Diagnostics.Append(diags...)
 				if resp.Diagnostics.HasError() {
 					return

--- a/pkg/talos/talos_machine_configuration_data_source.go
+++ b/pkg/talos/talos_machine_configuration_data_source.go
@@ -278,7 +278,7 @@ func (d *talosMachineConfigurationDataSource) Read(ctx context.Context, req data
 	state.MachineConfiguration = basetypes.NewStringValue(machineConfiguration)
 	state.ID = state.ClusterName
 
-	diags = resp.State.Set(ctx, state)
+	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {

--- a/pkg/talos/talos_machine_disks_data_source.go
+++ b/pkg/talos/talos_machine_disks_data_source.go
@@ -422,7 +422,7 @@ func (d *talosMachineDisksDataSource) Read(ctx context.Context, req datasource.R
 
 	state.ID = basetypes.NewStringValue("machine_disks")
 
-	diags = resp.State.Set(ctx, state)
+	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {

--- a/pkg/talos/talos_machine_secrets_resource.go
+++ b/pkg/talos/talos_machine_secrets_resource.go
@@ -585,7 +585,7 @@ func (r *talosMachineSecretsResource) UpgradeState(_ context.Context) map[int64]
 				}
 
 				// Set state to fully populated data
-				diags = resp.State.Set(ctx, state)
+				diags = resp.State.Set(ctx, &state)
 				resp.Diagnostics.Append(diags...)
 				if resp.Diagnostics.HasError() {
 					return
@@ -632,7 +632,7 @@ func (r *talosMachineSecretsResource) ImportState(ctx context.Context, req resou
 	}
 
 	// Set state to fully populated data
-	diags := resp.State.Set(ctx, state)
+	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
Fix resourceplanmodifiers for `talos_cluster_kubeconfig_resource`. Also use pointer to set state everywhere, otherwise the provider shows some weird inconsistencies.

Part of: #203