### PR TITLE
feat: configurable cert refresh time for kubeconfig

### DIFF
--- a/docs/resources/cluster_kubeconfig.md
+++ b/docs/resources/cluster_kubeconfig.md
@@ -69,6 +69,7 @@ resource "talos_cluster_kubeconfig" "this" {
 
 ### Optional
 
+- `certificate_renewal_duration` (String) The duration in hours before the certificate is renewed, defaults to 720h. Must be a valid duration string
 - `endpoint` (String) endpoint to use for the talosclient. If not set, the node value will be used
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/pkg/talos/talos_cluster_kubeconfig_data_source.go
+++ b/pkg/talos/talos_cluster_kubeconfig_data_source.go
@@ -121,8 +121,6 @@ func (d *talosClusterKubeConfigDataSource) Schema(ctx context.Context, _ datasou
 }
 
 // Read implements the datasource.DataSource interface.
-//
-//nolint:dupl
 func (d *talosClusterKubeConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var obj types.Object
 


### PR DESCRIPTION
Support configurable cert refresh time for `talos_cluster_kubeconfig`.

Fixes: #203