### PR TITLE
fix: drop talos<->k8s compatibility check

### DIFF
--- a/pkg/talos/talos_machine_configuration_data_source.go
+++ b/pkg/talos/talos_machine_configuration_data_source.go
@@ -6,7 +6,6 @@ package talos
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -16,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/siderolabs/crypto/x509"
-	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
-	"github.com/siderolabs/talos/pkg/machinery/compatibility"
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
@@ -332,47 +329,6 @@ func (d *talosMachineConfigurationDataSource) ValidateConfig(ctx context.Context
 		)
 
 		return
-	}
-
-	if !state.KubernetesVersion.IsUnknown() && !state.KubernetesVersion.IsNull() && !state.TalosVersion.IsUnknown() {
-		k8sVersionCompatibility, err := compatibility.ParseKubernetesVersion(strings.TrimPrefix(state.KubernetesVersion.ValueString(), "v"))
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"kubernetes_version is invalid",
-				err.Error(),
-			)
-
-			return
-		}
-
-		talosVersionInfo := &machineapi.VersionInfo{}
-
-		if state.TalosVersion.IsNull() {
-			talosVersionInfo.Tag = gendata.VersionTag
-		}
-
-		if !state.TalosVersion.IsNull() {
-			talosVersionInfo.Tag = state.TalosVersion.ValueString()
-		}
-
-		talosVersionCompatibility, err := compatibility.ParseTalosVersion(talosVersionInfo)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"talos_version is invalid",
-				err.Error(),
-			)
-
-			return
-		}
-
-		if err := k8sVersionCompatibility.SupportedWith(talosVersionCompatibility); err != nil {
-			resp.Diagnostics.AddError(
-				"talos_version is not compatible with kubernetes_version",
-				err.Error(),
-			)
-
-			return
-		}
 	}
 }
 

--- a/pkg/talos/talos_machine_configuration_data_source_test.go
+++ b/pkg/talos/talos_machine_configuration_data_source_test.go
@@ -191,25 +191,11 @@ func TestAccTalosMachineConfigurationDataSource(t *testing.T) {
 				Config:      testAccTalosMachineConfigurationDataSourceConfig("", "example-cluster-6", "control", "https://cluster.local", "", false, false, true, true),
 				ExpectError: regexp.MustCompile("Attribute machine_type value must be one of:"),
 			},
-			// test validating kubernetes compatibility with the default talos version
-			{
-				Config:      testAccTalosMachineConfigurationDataSourceConfig("", "example-cluster-7", "controlplane", "https://cluster.local", "v1.23.0", false, false, true, true),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("version of Kubernetes 1.23.0 is too old to be used with Talos %s", strings.TrimPrefix(gendata.VersionTag, "v"))),
-			},
-			// test validating kubernetes compatibility with a specific talos version
-			{
-				Config:      testAccTalosMachineConfigurationDataSourceConfig("v1.3", "example-cluster-8", "controlplane", "https://cluster.local", "v1.23.0", false, false, true, true),
-				ExpectError: regexp.MustCompile("version of Kubernetes 1.23.0 is too old to be used with Talos 1.3.0"),
-			},
 			// test validating config patches at plan time
 			{
 				PlanOnly:    true,
 				Config:      testAccTalosMachineConfigurationDataSourceConfig("v1.3", "example-cluster-8", "controlplane", "https://cluster.local", "v1.23.0", true, true, true, true),
 				ExpectError: regexp.MustCompile("unknown keys found during decoding:"),
-			},
-			{ // this is just added so that the plan only test above doesn't fail
-				PlanOnly: true,
-				Config:   testAccTalosMachineConfigurationDataSourceConfig("v1.3", "example-cluster-8", "controlplane", "https://cluster.local", "", false, false, true, true),
 			},
 		},
 	})


### PR DESCRIPTION
We don't have correct way of knowing which talos version or the k8s version the cluster is currently running, so drop the check which was based on talos version contract which would prevent setting kubernetes version if the cluster was initially created with an old version contract.

Fixes: #228