### PR TITLE
docs: fix reference to non-existing attribute in talos_image_factory_urls docs

### DIFF
--- a/docs/data-sources/image_factory_urls.md
+++ b/docs/data-sources/image_factory_urls.md
@@ -20,7 +20,7 @@ data "talos_image_factory_urls" "this" {
 }
 
 output "installer_image" {
-  value = data.talos_image_factory_urls.this.installer_image
+  value = data.talos_image_factory_urls.this.urls.installer
 }
 ```
 

--- a/examples/data-sources/talos_image_factory_urls/data-source.tf
+++ b/examples/data-sources/talos_image_factory_urls/data-source.tf
@@ -5,5 +5,5 @@ data "talos_image_factory_urls" "this" {
 }
 
 output "installer_image" {
-  value = data.talos_image_factory_urls.this.installer_image
+  value = data.talos_image_factory_urls.this.urls.installer
 }


### PR DESCRIPTION
This stumped me for a while today, until I read the docs more closely. Turns out `installer_image` is not a valid attribute on `talos_image_factory_urls`.