### PR TITLE
feat: sanitize the version arg in the urls data source

### DIFF
--- a/pkg/talos/talos_image_factory_urls_data_source.go
+++ b/pkg/talos/talos_image_factory_urls_data_source.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/blang/semver/v4"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -264,7 +265,14 @@ func (d *talosImageFactoryURLSDataSource) Read(ctx context.Context, req datasour
 
 	architecture := config.Architecture.ValueString()
 	platform := config.Platform.ValueString()
-	talosVersion := config.TalosVersion.ValueString()
+	talosVersion := "v" + strings.TrimPrefix(config.TalosVersion.ValueString(), "v")
+
+	if _, err := semver.ParseTolerant(talosVersion); err != nil {
+		resp.Diagnostics.AddError("talos_version is not valid", "The provided version is not a valid semantic version.")
+
+		return
+	}
+
 	schematicID := config.SchematicID.ValueString()
 
 	uri, err := url.Parse(d.imageFactoryClient.BaseURL())

--- a/pkg/talos/talos_image_factory_urls_data_source_test.go
+++ b/pkg/talos/talos_image_factory_urls_data_source_test.go
@@ -24,6 +24,11 @@ func TestAccTalosImageFactoryURLsDataSource(t *testing.T) {
 				Config:      testAccTalosImageFactoryURLsBothSBCAndPlatformSetConfig(),
 				ExpectError: regexp.MustCompile("Invalid Attribute Combination"),
 			},
+			// Invalid Version
+			{
+				Config:      testAccTalosImageFactoryURLsInvalidVersionConfig(),
+				ExpectError: regexp.MustCompile("talos_version is not valid"),
+			},
 		},
 	})
 
@@ -151,7 +156,7 @@ func testAccTalosImageFactoryURLsMetalPlatformConfig() string {
 provider "talos" {}
 
 data "talos_image_factory_urls" "this" {
-	talos_version = "v1.7.5"
+	talos_version = "1.7.5"
 	schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
 	platform = "metal"
 }
@@ -203,6 +208,18 @@ data "talos_image_factory_urls" "this" {
 	talos_version = "v1.7.5"
 	schematic_id = "ee21ef4a5ef808a9b7484cc0dda0f25075021691c8c09a276591eedb638ea1f9"
 	sbc = "rpi_generic"
+}
+`
+}
+
+func testAccTalosImageFactoryURLsInvalidVersionConfig() string {
+	return `
+provider "talos" {}
+
+data "talos_image_factory_urls" "this" {
+	talos_version = "invalid_version"
+	schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+	platform = "metal"
 }
 `
 }


### PR DESCRIPTION
This pull request fixes #247 

It parses the provided talos_version argument and checks that it can be converted to a Semantic Version, if it can it is converted into a string and prefixed with "v".