### PR TITLE
Option to skip worker node checks

### DIFF
--- a/pkg/talos/talos_cluster_health_data_source.go
+++ b/pkg/talos/talos_cluster_health_data_source.go
@@ -35,6 +35,7 @@ type talosClusterHealthDataSourceModelV0 struct {
 	ClientConfiguration  clientConfiguration `tfsdk:"client_configuration"`
 	Timeouts             timeouts.Value      `tfsdk:"timeouts"`
 	SkipKubernetesChecks types.Bool          `tfsdk:"skip_kubernetes_checks"`
+	SkipWorkerNodeChecks types.Bool          `tfsdk:"skip_worker_node_checks"`
 }
 
 type clusterNodes struct {
@@ -223,6 +224,10 @@ func (d *talosClusterHealthDataSource) Read(ctx context.Context, req datasource.
 		DefaultClient: c,
 	}
 	defer clientProvider.Close() //nolint:errcheck
+
+	if state.SkipWorkerNodeChecks.ValueBool() {
+		workerNodes = []string{}
+	}
 
 	nodeInfos, err := newClusterNodes(controlPlaneNodes, workerNodes)
 	if err != nil {


### PR DESCRIPTION
Some provider users have been complaining about node health check issues. It has been described on the issue board that some want a way to skip some node checks, so they can focus on ensuring the cluster endpoint, is healthy. I'm thinking this gives a way for users to focus on desired health statuses and not get lost in worker node status reports.

Since you can't directly change the behaviour of health checks since they are written in talos/, I thought instead you could simply pass workerNodes as empty, therefore not checking any of the workerNodes.