### PR TITLE
feat(talos_machine_configuration_apply): add prevent_uncontrolled_reboots option

### DIFF
--- a/docs/resources/machine_configuration_apply.md
+++ b/docs/resources/machine_configuration_apply.md
@@ -53,7 +53,7 @@ resource "talos_machine_configuration_apply" "this" {
 
 ### Optional
 
-- `apply_mode` (String) The mode of the apply operation
+- `apply_mode` (String) The mode of the apply operation. Use 'staged_if_needing_reboot' for automatic reboot prevention: performs a dry-run and uses 'staged' mode if reboot is needed, 'auto' otherwise
 - `config_patches` (List of String) The list of config patches to apply
 - `endpoint` (String) The endpoint of the machine to bootstrap
 - `on_destroy` (Attributes) Actions to be taken on destroy, if *reset* is not set this is a no-op.
@@ -66,6 +66,7 @@ then a subsequent *terraform destroy* for the changes to take effect due to limi
 
 - `id` (String) This is a unique identifier for the machine
 - `machine_configuration` (String, Sensitive) The generated machine configuration after applying patches
+- `resolved_apply_mode` (String) The actual apply mode used. When apply_mode is 'staged_if_needing_reboot', shows the resolved mode ('auto' or 'staged') based on dry-run analysis. Equals apply_mode for other modes.
 
 <a id="nestedatt--client_configuration"></a>
 ### Nested Schema for `client_configuration`


### PR DESCRIPTION
 Add a new `prevent_uncontrolled_reboots` boolean attribute to the `talos_machine_configuration_apply` resource to prevent uncontrolled reboots during configuration updates.

 ## Motivation

 When applying Talos machine configurations with `apply_mode=auto`, Terraform may automatically reboot nodes if the configuration changes require it. This can be problematic in production environments where reboots need to be carefully controlled and scheduled.

 ## Changes

 ### Feature
 - **New attribute**: `prevent_uncontrolled_reboots` (boolean, default: `false`)
 - **Behavior**: When enabled with `apply_mode=auto`, performs a dry-run check during `terraform plan`
   - If reboot is required → automatically switches to `staged` mode
   - If no reboot needed → proceeds with `auto` mode normally
 - **User feedback**: Clear warning message with manual reboot command when mode is switched

 ### Implementation
 - Added schema attribute with proper defaults and description
 - Created `handleRebootPrevention()` helper function to encapsulate the logic
 - Integrated dry-run API call to Talos to detect reboot requirements

 ### Testing
 - Added acceptance test `TestAccTalosMachineConfigurationApplyResourcePreventReboots`
 - But a full integration test is really hard to perform because it only affects resource updates. This means you need to set up a cluster, then make a modification that requires a reboot, and apply the updated resource. In addition, I'm developing in an environment that doesn’t allow me to run Terraform acceptance tests (I can't use libvirt).

 ## Result :
### When a change is made that requires a reboot, the following happens:
 ```hcl
Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw1"] will be updated in-place
  ~ resource "talos_machine_configuration_apply" "controlplane" {
      ~ apply_mode                   = "auto" -> "staged"
        id                           = "machine_configuration_apply"
      ~ machine_configuration        = (sensitive value)
      ~ machine_configuration_input  = (sensitive value)
        # (4 unchanged attributes hidden)
    }

  # module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw2"] will be updated in-place
  ~ resource "talos_machine_configuration_apply" "controlplane" {
      ~ apply_mode                   = "auto" -> "staged"
        id                           = "machine_configuration_apply"
      ~ machine_configuration        = (sensitive value)
      ~ machine_configuration_input  = (sensitive value)
        # (4 unchanged attributes hidden)
    }

  # module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw3"] will be updated in-place
  ~ resource "talos_machine_configuration_apply" "controlplane" {
      ~ apply_mode                   = "auto" -> "staged"
        id                           = "machine_configuration_apply"
      ~ machine_configuration        = (sensitive value)
      ~ machine_configuration_input  = (sensitive value)
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
╷
│ Warning: Reboot prevented - switched to staged mode
│ 
│   with module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw3"],
│   on ../../../modules/k8s/talos/cluster/07-apply_configuration.tf line 1, in resource "talos_machine_configuration_apply" "controlplane":
│    1: resource "talos_machine_configuration_apply" "controlplane" {
│ 
│ Node 172.20.68.4: Configuration requires reboot. Mode automatically changed to 'staged'. Manually reboot
│ with: talosctl reboot --nodes 172.20.68.4
│ 
│ (and 2 more similar warnings elsewhere)
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw1"]: Modifying... [id=machine_configuration_apply]
module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw3"]: Modifying... [id=machine_configuration_apply]
module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw2"]: Modifying... [id=machine_configuration_apply]
module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw3"]: Modifications complete after 0s [id=machine_configuration_apply]
module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw1"]: Modifications complete after 0s [id=machine_configuration_apply]
module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw2"]: Modifications complete after 0s [id=machine_configuration_apply]
╷
│ Warning: Reboot prevented - switched to staged mode
│ 
│   with module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw1"],
│   on ../../../modules/k8s/talos/cluster/07-apply_configuration.tf line 1, in resource "talos_machine_configuration_apply" "controlplane":
│    1: resource "talos_machine_configuration_apply" "controlplane" {
│ 
│ Node 172.20.68.2: Configuration requires reboot. Mode automatically changed to 'staged'. Manually reboot
│ with: talosctl reboot --nodes 172.20.68.2
│ 
│ (and 2 more similar warnings elsewhere)
╵
```

### If another Terraform apply is run before rebooting the nodes:
```hcl
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no
changes are needed.
╷
│ Warning: Reboot prevented - switched to staged mode
│ 
│   with module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw2"],
│   on ../../../modules/k8s/talos/cluster/07-apply_configuration.tf line 1, in resource "talos_machine_configuration_apply" "controlplane":
│    1: resource "talos_machine_configuration_apply" "controlplane" {
│ 
│ Node 172.20.68.3: Configuration requires reboot. Mode automatically changed to 'staged'. Manually reboot
│ with: talosctl reboot --nodes 172.20.68.3
│ 
│ (and 2 more similar warnings elsewhere)
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

### After rebooting the nodes, the state needs to be fixed:
```hcl
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw1"] will be updated in-place
  ~ resource "talos_machine_configuration_apply" "controlplane" {
      ~ apply_mode                   = "staged" -> "auto"
        id                           = "machine_configuration_apply"
        # (6 unchanged attributes hidden)
    }

  # module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw2"] will be updated in-place
  ~ resource "talos_machine_configuration_apply" "controlplane" {
      ~ apply_mode                   = "staged" -> "auto"
        id                           = "machine_configuration_apply"
        # (6 unchanged attributes hidden)
    }

  # module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw3"] will be updated in-place
  ~ resource "talos_machine_configuration_apply" "controlplane" {
      ~ apply_mode                   = "staged" -> "auto"
        id                           = "machine_configuration_apply"
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw2"]: Modifying... [id=machine_configuration_apply]
module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw3"]: Modifying... [id=machine_configuration_apply]
module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw1"]: Modifying... [id=machine_configuration_apply]
module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw3"]: Modifications complete after 0s [id=machine_configuration_apply]
module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw1"]: Modifications complete after 0s [id=machine_configuration_apply]
module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cpw2"]: Modifications complete after 0s [id=machine_configuration_apply]

Apply complete! Resources: 0 added, 3 changed, 0 destroyed.
```