### PR TITLE
Fix deprecation notice for RFC 6902 JSON patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ https://github.com/siderolabs/terraform-provider-talos/issues.
 
 ### config patches
 
-JSON6502 patches are no longer supported, use strategic patches instead.
+RFC 6902 JSON patches are no longer supported, use strategic patches instead.
 
 
 ### Component Updates


### PR DESCRIPTION
I think "JSON6502" is just a typo for RFC 6902 (JSON Patch). The [v0.10.0](https://github.com/siderolabs/terraform-provider-talos/releases/tag/v0.10.0) release notes use the same phrasing.