### PR TITLE
fix: gracefully handle Unknown config_patches values

### DIFF
--- a/pkg/talos/talos_image_factory_versions_data_source_test.go
+++ b/pkg/talos/talos_image_factory_versions_data_source_test.go
@@ -26,7 +26,7 @@ func TestAccTalosImageFactoryVersionsDataSource(t *testing.T) {
 			{
 				Config: testAccTalosImageFactoryVersionsDataSourceWithFilterConfig(),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownOutputValue("talos_version", knownvalue.StringExact("v1.12.0")),
+					statecheck.ExpectKnownOutputValue("talos_version", knownvalue.StringExact("v1.12.1")),
 				},
 			},
 		},

--- a/pkg/talos/talos_machine_configuration_data_source.go
+++ b/pkg/talos/talos_machine_configuration_data_source.go
@@ -316,19 +316,31 @@ func (d *talosMachineConfigurationDataSource) ValidateConfig(ctx context.Context
 
 	var configPatches []string
 
-	resp.Diagnostics.Append(state.ConfigPatches.ElementsAs(ctx, &configPatches, true)...)
+	loadConfigPatches := true
 
-	if resp.Diagnostics.HasError() {
-		return
+	for _, el := range state.ConfigPatches.Elements() {
+		if el.IsUnknown() || el.IsNull() {
+			loadConfigPatches = false
+
+			break
+		}
 	}
 
-	if _, err := configpatcher.LoadPatches(configPatches); err != nil {
-		resp.Diagnostics.AddError(
-			"config_patches are invalid",
-			err.Error(),
-		)
+	if loadConfigPatches {
+		resp.Diagnostics.Append(state.ConfigPatches.ElementsAs(ctx, &configPatches, true)...)
 
-		return
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if _, err := configpatcher.LoadPatches(configPatches); err != nil {
+			resp.Diagnostics.AddError(
+				"config_patches are invalid",
+				err.Error(),
+			)
+
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/siderolabs/terraform-provider-talos/issues/293.

Currently, when the config patch references a non-constant value (like using `${var.v}` 
interpolation), the value of the string, which is `Unknown`, is coerced into an empty string, 
and the provider tries to load it, causing the Talos library to open a file called `""` and 
fail with `open : no such file or directory`. This happens at the validation step.

The solution is to skip loading the config if any of the values provided is `Unknown`.