### PR TITLE
feat: exact match extensions filter

### DIFF
--- a/docs/data-sources/image_factory_extensions_versions.md
+++ b/docs/data-sources/image_factory_extensions_versions.md
@@ -36,12 +36,21 @@ data "talos_image_factory_extensions_versions" "this" {
 
 ### Optional
 
+- `exact_filters` (Attributes) The filter to apply to the extensions list. (see [below for nested schema](#nestedatt--exact_filters))
 - `filters` (Attributes) The filter to apply to the extensions list. (see [below for nested schema](#nestedatt--filters))
 
 ### Read-Only
 
 - `extensions_info` (List of Object) The list of available extensions for the specified talos version. (see [below for nested schema](#nestedatt--extensions_info))
 - `id` (String) The ID of this resource.
+
+<a id="nestedatt--exact_filters"></a>
+### Nested Schema for `exact_filters`
+
+Optional:
+
+- `names` (List of String) The exact name match of the extension to filter by.
+
 
 <a id="nestedatt--filters"></a>
 ### Nested Schema for `filters`

--- a/pkg/talos/talos_image_factory_extensions_versions_data_source_test.go
+++ b/pkg/talos/talos_image_factory_extensions_versions_data_source_test.go
@@ -28,6 +28,13 @@ func TestAccTalosImageFactoryExtensionsVersionsDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.talos_image_factory_extensions_versions.this", "extensions_info.0.name", "siderolabs/nvidia-container-toolkit"),
 				),
 			},
+			{
+				Config: testAccTalosImageFactoryExtensionsVersionsDataSourceConfigWithExactFilters(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.talos_image_factory_extensions_versions.this", "extensions_info.#", "1"),
+					resource.TestCheckResourceAttr("data.talos_image_factory_extensions_versions.this", "extensions_info.0.name", "siderolabs/tailscale"),
+				),
+			},
 		},
 	})
 }
@@ -52,6 +59,22 @@ data "talos_image_factory_extensions_versions" "this" {
 		names = [
 			"nvidia",
 			"tailscale"
+		]
+	}
+}
+`
+}
+
+func testAccTalosImageFactoryExtensionsVersionsDataSourceConfigWithExactFilters() string {
+	return `
+provider "talos" {}
+
+data "talos_image_factory_extensions_versions" "this" {
+	talos_version = "v1.7.0"
+	exact_filters = {
+		names = [
+			"nvidia",
+			"siderolabs/tailscale"
 		]
 	}
 }


### PR DESCRIPTION
I am using the `siderolabs/xe` extension for my talos image. When using the the data source `talos_image_factory_extensions_versions` and setting the filter to `siderolabs/xe` the xe extension as well as the `siderolabs/xen-guest-agent` extension will be returned. 

The `xen-guest-agent` extension I don't want and causes an infinite error log loop on my talos instances.

This is my attempt to mitigate this issue by adding a `exact_filters` attribute to the data source, so that I can get only the `xe` extension.