### PR TITLE
fix: prevent empty resolved_apply_mode when reusing state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/siderolabs/terraform-provider-talos
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/pkg/talos/talos_machine_configuration_apply_resource.go
+++ b/pkg/talos/talos_machine_configuration_apply_resource.go
@@ -836,6 +836,25 @@ func setResolvedApplyMode(ctx context.Context, resp *resource.ModifyPlanResponse
 	resp.Diagnostics.Append(diags...)
 }
 
+func dryRunNeedsReboot(cfgBytes []byte, needsReboot *bool) func(context.Context, *client.Client) error {
+	return func(nodeCtx context.Context, c *client.Client) error {
+		applyResp, err := c.ApplyConfiguration(nodeCtx, &machineapi.ApplyConfigurationRequest{
+			Mode:   machineapi.ApplyConfigurationRequest_AUTO,
+			Data:   cfgBytes,
+			DryRun: true,
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(applyResp.Messages) > 0 {
+			*needsReboot = (applyResp.Messages[0].Mode == machineapi.ApplyConfigurationRequest_REBOOT)
+		}
+
+		return nil
+	}
+}
+
 func (p *talosMachineConfigurationApplyResource) handleRebootPrevention(
 	ctx context.Context,
 	req resource.ModifyPlanRequest,
@@ -871,9 +890,11 @@ func (p *talosMachineConfigurationApplyResource) handleRebootPrevention(
 		}
 
 		if currentState.MachineConfiguration.Equal(types.StringValue(string(cfgBytes))) {
-			setResolvedApplyMode(ctx, resp, currentState.ResolvedApplyMode.ValueString())
+			if !currentState.ResolvedApplyMode.IsNull() && currentState.ResolvedApplyMode.ValueString() != "" {
+				setResolvedApplyMode(ctx, resp, currentState.ResolvedApplyMode.ValueString())
 
-			return
+				return
+			}
 		}
 	}
 
@@ -917,22 +938,7 @@ func (p *talosMachineConfigurationApplyResource) handleRebootPrevention(
 	var needsReboot bool
 
 	err = talosClientOp(ctx, endpoint, planState.Node.ValueString(), talosClientConfig,
-		func(nodeCtx context.Context, c *client.Client) error {
-			applyResp, applyErr := c.ApplyConfiguration(nodeCtx, &machineapi.ApplyConfigurationRequest{
-				Mode:   machineapi.ApplyConfigurationRequest_AUTO,
-				Data:   cfgBytes,
-				DryRun: true,
-			})
-			if applyErr != nil {
-				return applyErr
-			}
-
-			if len(applyResp.Messages) > 0 {
-				needsReboot = (applyResp.Messages[0].Mode == machineapi.ApplyConfigurationRequest_REBOOT)
-			}
-
-			return nil
-		},
+		dryRunNeedsReboot(cfgBytes, &needsReboot),
 	)
 	if err != nil {
 		resp.Diagnostics.AddWarning(

--- a/pkg/talos/talos_machine_configuration_apply_resource_test.go
+++ b/pkg/talos/talos_machine_configuration_apply_resource_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/siderolabs/talos/pkg/machinery/gendata"
 )
@@ -78,6 +79,135 @@ func TestAccTalosMachineConfigurationApplyResourceAutoStaged(t *testing.T) {
 					resource.TestCheckResourceAttr("talos_machine_configuration_apply.staged_if_needing_reboot", "id", "machine_configuration_apply"),
 					resource.TestCheckResourceAttr("talos_machine_configuration_apply.staged_if_needing_reboot", "apply_mode", "staged_if_needing_reboot"),
 					resource.TestCheckResourceAttr("talos_machine_configuration_apply.staged_if_needing_reboot", "resolved_apply_mode", "staged"),
+				),
+			},
+		},
+	})
+}
+
+// logApplyModeState returns a TestCheckFunc that logs the apply_mode and resolved_apply_mode
+// attributes of the staged_if_needing_reboot resource for debugging upgrade tests.
+func logApplyModeState(t *testing.T, stepName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources["talos_machine_configuration_apply.staged_if_needing_reboot"]
+		if !ok {
+			t.Logf("[%s] Resource not found in state", stepName)
+
+			return nil
+		}
+
+		t.Logf("[%s] apply_mode = %q", stepName, rs.Primary.Attributes["apply_mode"])
+
+		resolvedApplyMode, exists := rs.Primary.Attributes["resolved_apply_mode"]
+
+		switch {
+		case !exists:
+			t.Logf("[%s] resolved_apply_mode = <DOES NOT EXIST>", stepName)
+		case resolvedApplyMode == "":
+			t.Logf("[%s] resolved_apply_mode = <EMPTY STRING>", stepName)
+		default:
+			t.Logf("[%s] resolved_apply_mode = %q", stepName, resolvedApplyMode)
+		}
+
+		return nil
+	}
+}
+
+// TestAccTalosMachineConfigurationApplyResourceUpgradeWithResolvedApplyModeBug tests the bug in v0.10.1.
+//
+// Bug scenario: v0.10.0 → v0.10.1
+//   - v0.10.0: staged_if_needing_reboot and resolved_apply_mode don't exist.
+//   - v0.10.1: add staged_if_needing_reboot, resolved_apply_mode appears but is EMPTY (this is the bug).
+func TestAccTalosMachineConfigurationApplyResourceUpgradeWithResolvedApplyModeBug(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.ParallelTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			// Step 1: v0.10.0 - staged_if_needing_reboot doesn't exist, use default apply_mode
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"talos": {
+						VersionConstraint: "=0.10.0",
+						Source:            "siderolabs/talos",
+					},
+					"libvirt": {
+						Source:            "dmacvicar/libvirt",
+						VersionConstraint: "= 0.8.3",
+					},
+				},
+				Config: testAccTalosMachineConfigurationApplyResourceConfigAutoStagedUpgrade(rName, "auto"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					logApplyModeState(t, "v0.10.0 - baseline"),
+					resource.TestCheckResourceAttr("talos_machine_configuration_apply.staged_if_needing_reboot", "apply_mode", "auto"),
+				),
+			},
+			// Step 2: v0.10.1 - switch to staged_if_needing_reboot, resolved_apply_mode is EMPTY (bug)
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"talos": {
+						VersionConstraint: "=0.10.1",
+						Source:            "siderolabs/talos",
+					},
+					"libvirt": {
+						Source:            "dmacvicar/libvirt",
+						VersionConstraint: "= 0.8.3",
+					},
+				},
+				Config: testAccTalosMachineConfigurationApplyResourceConfigAutoStagedUpgrade(rName, "staged_if_needing_reboot"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					logApplyModeState(t, "v0.10.1 - BUG: resolved_apply_mode is empty"),
+					resource.TestCheckResourceAttr("talos_machine_configuration_apply.staged_if_needing_reboot", "apply_mode", "staged_if_needing_reboot"),
+					// Bug: resolved_apply_mode is empty here because config didn't change
+					resource.TestCheckResourceAttr("talos_machine_configuration_apply.staged_if_needing_reboot", "resolved_apply_mode", ""),
+				),
+			},
+		},
+	})
+}
+
+// TestAccTalosMachineConfigurationApplyResourceUpgradeWithResolvedApplyModeFix tests the fix for empty resolved_apply_mode.
+//
+// Fix scenario: v0.10.0 → current version
+//   - v0.10.0: staged_if_needing_reboot and resolved_apply_mode don't exist.
+//   - Current version: resolved_apply_mode is correctly computed (not empty).
+func TestAccTalosMachineConfigurationApplyResourceUpgradeWithResolvedApplyModeFix(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.ParallelTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			// Step 1: v0.10.0 - staged_if_needing_reboot doesn't exist, use default apply_mode
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"talos": {
+						VersionConstraint: "=0.10.0",
+						Source:            "siderolabs/talos",
+					},
+					"libvirt": {
+						Source:            "dmacvicar/libvirt",
+						VersionConstraint: "= 0.8.3",
+					},
+				},
+				Config: testAccTalosMachineConfigurationApplyResourceConfigAutoStagedUpgrade(rName, "auto"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					logApplyModeState(t, "v0.10.0 - baseline"),
+					resource.TestCheckResourceAttr("talos_machine_configuration_apply.staged_if_needing_reboot", "apply_mode", "auto"),
+				),
+			},
+			// Step 2: Current version - switch to staged_if_needing_reboot, resolved_apply_mode is correctly computed
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"libvirt": {
+						Source:            "dmacvicar/libvirt",
+						VersionConstraint: "= 0.8.3",
+					},
+				},
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Config:                   testAccTalosMachineConfigurationApplyResourceConfigAutoStagedUpgrade(rName, "staged_if_needing_reboot"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					logApplyModeState(t, "current version - FIX: resolved_apply_mode is computed"),
+					resource.TestCheckResourceAttr("talos_machine_configuration_apply.staged_if_needing_reboot", "apply_mode", "staged_if_needing_reboot"),
+					// Fix: resolved_apply_mode should now be computed (not empty)
+					resource.TestCheckResourceAttrSet("talos_machine_configuration_apply.staged_if_needing_reboot", "resolved_apply_mode"),
 				),
 			},
 		},
@@ -273,6 +403,26 @@ func TestAccTalosMachineConfigurationApplyWithEphemeralClientConfigWO(t *testing
 			},
 		},
 	})
+}
+
+func testAccTalosMachineConfigurationApplyResourceConfigAutoStagedUpgrade(rName, applyMode string) string {
+	config := dynamicConfig{
+		Provider:        "talos",
+		ResourceName:    rName,
+		WithApplyConfig: false,
+		WithBootstrap:   false,
+	}
+
+	baseConfig := config.render()
+
+	return baseConfig + `
+resource "talos_machine_configuration_apply" "staged_if_needing_reboot" {
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.this.machine_configuration
+  node                        = libvirt_domain.cp.network_interface[0].addresses[0]
+  apply_mode                  = "` + applyMode + `"
+}
+`
 }
 
 func testAccTalosMachineConfigurationApplyWithEphemeralClientConfigWOConfig(rName string) string {


### PR DESCRIPTION
When using `apply_mode = "staged_if_needing_reboot"`, the provider performs a dry run to determine whether a reboot is required and sets `resolved_apply_mode` to either `"auto"` or `"staged"` accordingly.

## Problem

When the machine configuration had not changed between plan runs, the code attempted to reuse the previous `resolved_apply_mode` value from the state as an optimization to avoid unnecessary dry runs.

However, if the previous state contained an empty or null `resolved_apply_mode` (for example, after a provider upgrade where this attribute did not exist), the code would:

1. Retrieve an empty string from `currentState.ResolvedApplyMode`
2. Set `resolved_apply_mode` to this empty value
3. Return early, skipping the dry-run calculation

As a result, `resolved_apply_mode` remained empty in the plan. This not only prevented users from understanding which apply mode would actually be used, but also caused the apply phase to send a configuration with an empty mode, which was ultimately resolved as a forced reboot.

## Solution

Before reusing the cached `resolved_apply_mode` value, ensure that it is neither null nor empty. If it is, skip the early return and continue with the dry-run logic, which will correctly calculate and set the value.

This guarantees that `resolved_apply_mode` is always populated with a valid mode (`"auto"` or `"staged"`) when using `staged_if_needing_reboot`.

## Without this fix

```
  # module.talos_platform.module.cluster.talos_machine_configuration_apply.controlplane["cp3"] will be updated in-place
  ~ resource "talos_machine_configuration_apply" "controlplane" {
      ~ apply_mode                  = "auto" -> "staged_if_needing_reboot"
        id                          = "machine_configuration_apply"
      ~ machine_configuration       = (sensitive value)
      ~ machine_configuration_input = (sensitive value)
      + resolved_apply_mode         = "staged"
        # (3 unchanged attributes hidden)
    }

  # module.talos_platform.module.cluster.talos_machine_configuration_apply.worker["w1"] will be updated in-place
  ~ resource "talos_machine_configuration_apply" "worker" {
      ~ apply_mode                  = "auto" -> "staged_if_needing_reboot"
        id                          = "machine_configuration_apply"
      + resolved_apply_mode         = "" # HERE IS THE PROBLEM
        # (5 unchanged attributes hidden)
    }
```

Since there was no configuration change, the dry run was not executed during the plan phase, and `resolved_apply_mode` was left as an empty string.

During the apply phase, this resulted in sending an apply configuration with an empty mode to the node, which forced an unnecessary reboot.

## With this fix

The plan phase now forces a dry run when `resolved_apply_mode` is empty, ensuring it is correctly calculated:

```
  # module.talos_platform.module.cluster.talos_machine_configuration_apply.worker["w3"] will be updated in-place
  ~ resource "talos_machine_configuration_apply" "worker" {
      ~ apply_mode                  = "auto" -> "staged_if_needing_reboot"
        id                          = "machine_configuration_apply"
      + resolved_apply_mode         = "auto"
        # (5 unchanged attributes hidden)
    }
```

Sorry for the oversight in [https://github.com/siderolabs/terraform-provider-talos/pull/286](https://github.com/siderolabs/terraform-provider-talos/pull/286)
