### PR TITLE
fix: restore correct skip_kubernetes_checks behavior

### DIFF
--- a/pkg/talos/talos_cluster_health_data_source.go
+++ b/pkg/talos/talos_cluster_health_data_source.go
@@ -249,7 +249,7 @@ func (d *talosClusterHealthDataSource) Read(ctx context.Context, req datasource.
 
 	reporter := newReporter()
 
-	checks := slices.Concat(check.PreBootSequenceChecks(), check.K8sComponentsReadinessChecks())
+	checks := check.PreBootSequenceChecks()
 
 	if !state.SkipKubernetesChecks.ValueBool() {
 		checks = check.DefaultClusterChecks()

--- a/pkg/talos/talos_cluster_health_ephemeral_resource.go
+++ b/pkg/talos/talos_cluster_health_ephemeral_resource.go
@@ -7,7 +7,6 @@ package talos
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -213,7 +212,7 @@ func (r *talosClusterHealthEphemeralResource) Open(ctx context.Context, req ephe
 
 	reporter := newHealthReporter()
 
-	checks := slices.Concat(check.PreBootSequenceChecks(), check.K8sComponentsReadinessChecks())
+	checks := check.PreBootSequenceChecks()
 
 	if !config.SkipKubernetesChecks.ValueBool() {
 		checks = check.DefaultClusterChecks()


### PR DESCRIPTION
## Summary

- `skip_kubernetes_checks = true` was still running Kubernetes API checks, causing timeouts when the k8s API is unreachable
- Root cause: commit 7af49b3 changed the default check set to `slices.Concat(PreBootSequenceChecks(), K8sComponentsReadinessChecks())` without updating the condition, so the flag had no effect
- Fix restores the original intent from commit 11ae330: default to `PreBootSequenceChecks()` only, and use `DefaultClusterChecks()` when not skipping

Fixes #311