### PR TITLE
fix: remove unsupported windows/arm build target for Go 1.25

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,8 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Go 1.25 dropped support for the windows/arm (32-bit ARM) platform.