### PR TITLE
fix: rewrite ephemeral talos_client_configuration to generate from machine_secrets

### DIFF
--- a/docs/ephemeral-resources/client_configuration.md
+++ b/docs/ephemeral-resources/client_configuration.md
@@ -3,12 +3,12 @@
 page_title: "talos_client_configuration Ephemeral Resource - talos"
 subcategory: ""
 description: |-
-  Generate client configuration for a Talos cluster. This is an ephemeral resource that does not persist secrets in Terraform state.
+  Generate client configuration for a Talos cluster from machine secrets. This is an ephemeral resource that does not persist secrets in Terraform state. The admin client certificate is generated with pinned timestamps so talos_config is byte-identical on every open as long as machine_secrets and not_before are unchanged.
 ---
 
 # talos_client_configuration (Ephemeral Resource)
 
-Generate client configuration for a Talos cluster. This is an ephemeral resource that does not persist secrets in Terraform state.
+Generate client configuration for a Talos cluster from machine secrets. This is an ephemeral resource that does not persist secrets in Terraform state. The admin client certificate is generated with pinned timestamps so talos_config is byte-identical on every open as long as machine_secrets and not_before are unchanged.
 
 
 
@@ -17,22 +17,122 @@ Generate client configuration for a Talos cluster. This is an ephemeral resource
 
 ### Required
 
-- `client_configuration` (Attributes) The client configuration data (see [below for nested schema](#nestedatt--client_configuration))
 - `cluster_name` (String) The name of the cluster in the generated config
+- `machine_secrets` (Attributes) The secrets for the talos cluster (see [below for nested schema](#nestedatt--machine_secrets))
 
 ### Optional
 
+- `crt_ttl` (String) The lifetime of the generated admin client certificate as a Go duration string (e.g. "8760h" for 1 year, "87600h" for 10 years). Defaults to "87600h" (10 years). Only used when not_before is set; when not_before is omitted the cert uses the OS CA's NotAfter directly.
 - `endpoints` (List of String) endpoints to set in the generated config
 - `nodes` (List of String) nodes to set in the generated config
+- `not_before` (String) RFC3339 timestamp to use as the NotBefore field of the generated admin client certificate. When set, the certificate validity starts at this time and ends at not_before + crt_ttl. Persist this value in a terraform_data resource so it is stable across plans and the generated talos_config is byte-identical on every open. When omitted, the certificate uses the OS CA's own NotBefore/NotAfter timestamps.
 
 ### Read-Only
 
+- `client_configuration` (Attributes, Sensitive) The generated client configuration data (see [below for nested schema](#nestedatt--client_configuration))
 - `talos_config` (String, Sensitive) The generated client configuration
+
+<a id="nestedatt--machine_secrets"></a>
+### Nested Schema for `machine_secrets`
+
+Required:
+
+- `certs` (Attributes) The certs for the talos kubernetes cluster (see [below for nested schema](#nestedatt--machine_secrets--certs))
+- `cluster` (Attributes) The cluster secrets (see [below for nested schema](#nestedatt--machine_secrets--cluster))
+- `secrets` (Attributes) The secrets for the talos kubernetes cluster (see [below for nested schema](#nestedatt--machine_secrets--secrets))
+- `trustdinfo` (Attributes) The trustd info for the talos kubernetes cluster (see [below for nested schema](#nestedatt--machine_secrets--trustdinfo))
+
+<a id="nestedatt--machine_secrets--certs"></a>
+### Nested Schema for `machine_secrets.certs`
+
+Required:
+
+- `etcd` (Attributes) The certificate and key pair (see [below for nested schema](#nestedatt--machine_secrets--certs--etcd))
+- `k8s` (Attributes) The certificate and key pair (see [below for nested schema](#nestedatt--machine_secrets--certs--k8s))
+- `k8s_aggregator` (Attributes) The certificate and key pair (see [below for nested schema](#nestedatt--machine_secrets--certs--k8s_aggregator))
+- `k8s_serviceaccount` (Attributes) (see [below for nested schema](#nestedatt--machine_secrets--certs--k8s_serviceaccount))
+- `os` (Attributes) The certificate and key pair (see [below for nested schema](#nestedatt--machine_secrets--certs--os))
+
+<a id="nestedatt--machine_secrets--certs--etcd"></a>
+### Nested Schema for `machine_secrets.certs.etcd`
+
+Required:
+
+- `cert` (String) certificate data
+- `key` (String, Sensitive) key data
+
+
+<a id="nestedatt--machine_secrets--certs--k8s"></a>
+### Nested Schema for `machine_secrets.certs.k8s`
+
+Required:
+
+- `cert` (String) certificate data
+- `key` (String, Sensitive) key data
+
+
+<a id="nestedatt--machine_secrets--certs--k8s_aggregator"></a>
+### Nested Schema for `machine_secrets.certs.k8s_aggregator`
+
+Required:
+
+- `cert` (String) certificate data
+- `key` (String, Sensitive) key data
+
+
+<a id="nestedatt--machine_secrets--certs--k8s_serviceaccount"></a>
+### Nested Schema for `machine_secrets.certs.k8s_serviceaccount`
+
+Required:
+
+- `key` (String, Sensitive) The key for the k8s service account
+
+
+<a id="nestedatt--machine_secrets--certs--os"></a>
+### Nested Schema for `machine_secrets.certs.os`
+
+Required:
+
+- `cert` (String) certificate data
+- `key` (String, Sensitive) key data
+
+
+
+<a id="nestedatt--machine_secrets--cluster"></a>
+### Nested Schema for `machine_secrets.cluster`
+
+Required:
+
+- `id` (String) The cluster id
+- `secret` (String, Sensitive) The cluster secret
+
+
+<a id="nestedatt--machine_secrets--secrets"></a>
+### Nested Schema for `machine_secrets.secrets`
+
+Required:
+
+- `bootstrap_token` (String, Sensitive) The bootstrap token for the talos kubernetes cluster
+- `secretbox_encryption_secret` (String, Sensitive) The secretbox encryption secret for the talos kubernetes cluster
+
+Optional:
+
+- `aescbc_encryption_secret` (String, Sensitive) The aescbc encryption secret for the talos kubernetes cluster
+
+
+<a id="nestedatt--machine_secrets--trustdinfo"></a>
+### Nested Schema for `machine_secrets.trustdinfo`
+
+Required:
+
+- `token` (String, Sensitive) The trustd token for the talos kubernetes cluster
+
+
 
 <a id="nestedatt--client_configuration"></a>
 ### Nested Schema for `client_configuration`
 
-Required:
+Read-Only:
 
 - `ca_certificate` (String) The client CA certificate
 - `client_certificate` (String) The client certificate

--- a/examples/ephemeral-resources/basic/main.tf
+++ b/examples/ephemeral-resources/basic/main.tf
@@ -13,10 +13,10 @@ terraform {
 }
 
 # This example demonstrates the correct pattern for using ephemeral resources
-# with Talos. Machine secrets are persisted to Vault to ensure deterministic
-# infrastructure state across Terraform runs.
+# with Talos. Only machine_secrets is persisted to Vault — client_configuration
+# is a derived value regenerated on every apply from the CA key.
 
-# STEP 1: Generate and store machine secrets in Vault
+# STEP 1: Generate and store machine secrets in Vault.
 # The ephemeral resource generates secrets, which are immediately stored in Vault
 # using write-only attributes. After the initial run, this ephemeral resource won't
 # be evaluated again because data_json_wo_version is hardcoded.
@@ -26,30 +26,51 @@ resource "vault_kv_secret_v2" "talos_secrets" {
   mount = "secret"
   name  = "talos-example-cluster"
 
-  # Use write-only attributes to prevent secrets from being stored in Terraform state
+  # Only machine_secrets is persisted — client_configuration is derived and never stored.
   data_json_wo = jsonencode({
-    machine_secrets      = ephemeral.talos_machine_secrets.this.machine_secrets
-    client_configuration = ephemeral.talos_machine_secrets.this.client_configuration
+    machine_secrets = ephemeral.talos_machine_secrets.this.machine_secrets
   })
-  # Hardcoded version prevents unnecessary refreshes after initial creation
+  # Hardcoded version prevents unnecessary refreshes after initial creation.
   data_json_wo_version = 1
 }
 
-# STEP 2: Retrieve secrets ephemerally from Vault for cluster operations
+# STEP 2: Retrieve secrets ephemerally from Vault for cluster operations.
 # This ephemeral resource reads from Vault on every run, but values are never
-# stored in Terraform state. Referencing the resource attributes creates an
-# implicit dependency so Terraform creates the secret before reading it.
+# stored in Terraform state.
 ephemeral "vault_kv_secret_v2" "talos_secrets" {
   mount = vault_kv_secret_v2.talos_secrets.mount
   name  = vault_kv_secret_v2.talos_secrets.name
 }
 
 locals {
-  # Decode secrets from Vault
   talos_data = jsondecode(ephemeral.vault_kv_secret_v2.talos_secrets.data_json)
 }
 
-# Generate controlplane machine configuration using ephemeral secrets from Vault
+# STEP 3: Generate client credentials from machine_secrets on every apply.
+# The cert is generated locally from the Talos OS CA key — no live API call.
+# A 10-year lifetime matches the CA so no rotation is needed within the cluster lifetime.
+ephemeral "talos_client_configuration" "this" {
+  cluster_name    = "example-cluster"
+  machine_secrets = local.talos_data.machine_secrets
+  crt_ttl         = "87600h"
+  endpoints       = ["10.5.0.2"]
+  nodes           = ["10.5.0.2"]
+}
+
+# STEP 4: Persist talos_config to Vault for operators to use with talosctl.
+# data_json_wo_version = 1 suppresses plan diffs after initial creation.
+# Bump the version to force a refresh (e.g. after a CA rotation).
+resource "vault_kv_secret_v2" "talos_config" {
+  mount = "secret"
+  name  = "talos-example-cluster-config"
+
+  data_json_wo = jsonencode({
+    talos_config = ephemeral.talos_client_configuration.this.talos_config
+  })
+  data_json_wo_version = 1
+}
+
+# Generate controlplane machine configuration using ephemeral secrets from Vault.
 ephemeral "talos_machine_configuration" "controlplane" {
   cluster_name     = "example-cluster"
   cluster_endpoint = "https://10.5.0.2:6443"
@@ -67,16 +88,16 @@ ephemeral "talos_machine_configuration" "controlplane" {
   ]
 }
 
-# Apply configuration to a machine
+# Apply configuration to a machine.
 resource "talos_machine_configuration_apply" "controlplane" {
-  client_configuration_wo        = local.talos_data.client_configuration
+  client_configuration_wo        = ephemeral.talos_client_configuration.this.client_configuration
   machine_configuration_input_wo = ephemeral.talos_machine_configuration.controlplane.machine_configuration
   node                           = "10.5.0.2"
 }
 
-# Bootstrap the cluster
+# Bootstrap the cluster.
 resource "talos_machine_bootstrap" "this" {
-  client_configuration_wo = local.talos_data.client_configuration
+  client_configuration_wo = ephemeral.talos_client_configuration.this.client_configuration
   node                    = "10.5.0.2"
 
   depends_on = [
@@ -84,9 +105,9 @@ resource "talos_machine_bootstrap" "this" {
   ]
 }
 
-# Wait for cluster to be healthy (ephemeral - doesn't leak secrets to state)
+# Wait for cluster to be healthy (ephemeral — doesn't leak secrets to state).
 ephemeral "talos_cluster_health" "this" {
-  client_configuration   = local.talos_data.client_configuration
+  client_configuration   = ephemeral.talos_client_configuration.this.client_configuration
   endpoints              = ["10.5.0.2"]
   control_plane_nodes    = ["10.5.0.2"]
   worker_nodes           = []
@@ -97,9 +118,9 @@ ephemeral "talos_cluster_health" "this" {
   ]
 }
 
-# Retrieve cluster kubeconfig ephemerally
+# Retrieve cluster kubeconfig ephemerally.
 ephemeral "talos_cluster_kubeconfig" "this" {
-  client_configuration = local.talos_data.client_configuration
+  client_configuration = ephemeral.talos_client_configuration.this.client_configuration
   node                 = "10.5.0.2"
 
   depends_on = [
@@ -107,7 +128,7 @@ ephemeral "talos_cluster_kubeconfig" "this" {
   ]
 }
 
-# Output the kubeconfig (marked as ephemeral)
+# Output the kubeconfig (marked as ephemeral).
 output "kubeconfig" {
   value     = ephemeral.talos_cluster_kubeconfig.this.kubeconfig_raw
   sensitive = true

--- a/pkg/talos/rfc6979.go
+++ b/pkg/talos/rfc6979.go
@@ -1,0 +1,163 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+// RFC 6979 deterministic ECDSA nonce generation for P-256.
+// This produces signatures that are fully deterministic (no randomness),
+// which is required because Go 1.26+ ignores custom io.Reader in crypto/ecdsa.
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/asn1"
+	"io"
+	"math/big"
+)
+
+// deterministicECDSASigner wraps an ECDSA private key and produces RFC 6979
+// deterministic signatures instead of using random nonces.
+type deterministicECDSASigner struct {
+	key *ecdsa.PrivateKey
+}
+
+func (s *deterministicECDSASigner) Public() crypto.PublicKey {
+	return &s.key.PublicKey
+}
+
+func (s *deterministicECDSASigner) Sign(_ io.Reader, digest []byte, _ crypto.SignerOpts) ([]byte, error) {
+	r, ss := rfc6979Sign(s.key, digest)
+
+	return asn1.Marshal(struct {
+		R, S *big.Int
+	}{r, ss})
+}
+
+// rfc6979Sign computes an ECDSA signature using the deterministic nonce
+// generation algorithm from RFC 6979, Section 3.2.
+func rfc6979Sign(key *ecdsa.PrivateKey, hash []byte) (*big.Int, *big.Int) {
+	curve := key.Curve
+	n := curve.Params().N
+	qLen := (n.BitLen() + 7) / 8 // byte length of the curve order
+
+	// Use Bytes() instead of the deprecated D field.
+	// Bytes never returns an error for valid keys.
+	keyBytes, _ := key.Bytes() //nolint:errcheck
+	d := new(big.Int).SetBytes(keyBytes)
+
+	// int2octets: private key as a fixed-length big-endian integer.
+	x := keyBytes
+
+	// bits2octets: reduce hash modulo n, then encode as fixed-length.
+	h1 := bits2octets(hash, n, qLen)
+
+	// Section 3.2 steps a-f: initialize HMAC_DRBG.
+	hLen := sha256.Size // 32 for SHA-256
+	v := make([]byte, hLen)
+	k := make([]byte, hLen)
+
+	for i := range v {
+		v[i] = 0x01
+	}
+
+	// Step d: K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1))
+	k = hmacSHA256(k, v, []byte{0x00}, x, h1)
+	// Step e: V = HMAC_K(V)
+	v = hmacSHA256(k, v)
+	// Step f: K = HMAC_K(V || 0x01 || int2octets(x) || bits2octets(h1))
+	k = hmacSHA256(k, v, []byte{0x01}, x, h1)
+	// Step g: V = HMAC_K(V)
+	v = hmacSHA256(k, v)
+
+	// Step h: generate k candidates until valid.
+	for {
+		// For P-256 with SHA-256, one HMAC output (32 bytes) = qLen.
+		v = hmacSHA256(k, v)
+		kCandidate := bits2int(v, n)
+
+		if kCandidate.Sign() > 0 && kCandidate.Cmp(n) < 0 {
+			r, ss := rawECDSASign(curve, n, d, kCandidate, hash)
+			if r.Sign() > 0 && ss.Sign() > 0 {
+				return r, ss
+			}
+		}
+
+		// Not valid, update K and V per RFC 6979 step h.3.
+		k = hmacSHA256(k, v, []byte{0x00})
+		v = hmacSHA256(k, v)
+	}
+}
+
+// rawECDSASign computes (r, s) given a nonce k, following the standard ECDSA
+// signature algorithm.
+func rawECDSASign(curve elliptic.Curve, n, d, k *big.Int, hash []byte) (*big.Int, *big.Int) {
+	// R = k * G
+	// No non-deprecated API exposes the x-coordinate of a scalar multiplication.
+	rx, _ := curve.ScalarBaseMult(k.Bytes()) //nolint:staticcheck
+	r := new(big.Int).Mod(rx, n)
+
+	if r.Sign() == 0 {
+		return r, new(big.Int)
+	}
+
+	// s = k^-1 * (hash + r * d) mod n
+	e := bits2int(hash, n)
+	s := new(big.Int).Mul(r, d)
+	s.Add(s, e)
+
+	kInv := new(big.Int).ModInverse(k, n)
+	s.Mul(s, kInv)
+	s.Mod(s, n)
+
+	return r, s
+}
+
+// hmacSHA256 computes HMAC-SHA256(key, data...).
+func hmacSHA256(key []byte, data ...[]byte) []byte {
+	h := hmac.New(sha256.New, key)
+	for _, d := range data {
+		h.Write(d) //nolint:errcheck
+	}
+
+	return h.Sum(nil)
+}
+
+// int2octets converts a big.Int to a fixed-length (qLen) big-endian byte slice.
+func int2octets(v *big.Int, qLen int) []byte {
+	out := v.Bytes()
+	if len(out) >= qLen {
+		return out[:qLen]
+	}
+
+	padded := make([]byte, qLen)
+	copy(padded[qLen-len(out):], out)
+
+	return padded
+}
+
+// bits2int interprets a byte slice as a big-endian integer and reduces to
+// the bit length of n.
+func bits2int(b []byte, n *big.Int) *big.Int {
+	v := new(big.Int).SetBytes(b)
+	excess := len(b)*8 - n.BitLen()
+
+	if excess > 0 {
+		v.Rsh(v, uint(excess))
+	}
+
+	return v
+}
+
+// bits2octets converts a hash to a fixed-length byte slice reduced modulo n.
+func bits2octets(hash []byte, n *big.Int, qLen int) []byte {
+	z := bits2int(hash, n)
+	if z.Cmp(n) >= 0 {
+		z.Sub(z, n)
+	}
+
+	return int2octets(z, qLen)
+}

--- a/pkg/talos/rfc6979_test.go
+++ b/pkg/talos/rfc6979_test.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos //nolint:testpackage
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"encoding/hex"
+	"math/big"
+	"testing"
+)
+
+// TestRFC6979SignTestVectors validates the RFC 6979 implementation against
+// the official test vectors from RFC 6979 Appendix A.2.5 (ECDSA P-256 / SHA-256).
+func TestRFC6979SignTestVectors(t *testing.T) {
+	t.Parallel()
+
+	// Private key from RFC 6979 A.2.5.
+	xHex := "C9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721"
+
+	xBytes, err := hex.DecodeString(xHex)
+	if err != nil {
+		t.Fatalf("failed to decode test private key hex: %v", err)
+	}
+
+	key, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), xBytes)
+	if err != nil {
+		t.Fatalf("failed to parse test private key: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		message   string
+		expectedR string
+		expectedS string
+	}{
+		{
+			name:      "sample",
+			message:   "sample",
+			expectedR: "EFD48B2AACB6A8FD1140DD9CD45E81D69D2C877B56AAF991C34D0EA84EAF3716",
+			expectedS: "F7CB1C942D657C41D436C7A1B6E29F65F3E900DBB9AFF4064DC4AB2F843ACDA8",
+		},
+		{
+			name:      "test",
+			message:   "test",
+			expectedR: "F1ABB023518351CD71D881567B1EA663ED3EFCF6C5132B354F28D3B0B7D38367",
+			expectedS: "019F4113742A2B14BD25926B49C649155F267E60D3814B4C0CC84250E46F0083",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			hash := sha256.Sum256([]byte(tc.message))
+			r, s := rfc6979Sign(key, hash[:])
+
+			expectedR, _ := new(big.Int).SetString(tc.expectedR, 16)
+			expectedS, _ := new(big.Int).SetString(tc.expectedS, 16)
+
+			if r.Cmp(expectedR) != 0 {
+				t.Errorf("r mismatch for %q:\n  got:  %064X\n  want: %064X", tc.message, r, expectedR)
+			}
+
+			if s.Cmp(expectedS) != 0 {
+				t.Errorf("s mismatch for %q:\n  got:  %064X\n  want: %064X", tc.message, s, expectedS)
+			}
+		})
+	}
+}

--- a/pkg/talos/talos_client_configuration_ephemeral_resource.go
+++ b/pkg/talos/talos_client_configuration_ephemeral_resource.go
@@ -21,10 +21,13 @@ type talosClientConfigurationEphemeralResource struct{}
 
 type talosClientConfigurationEphemeralResourceModel struct {
 	ClusterName         types.String        `tfsdk:"cluster_name"`
-	ClientConfiguration clientConfiguration `tfsdk:"client_configuration"`
+	MachineSecrets      machineSecrets      `tfsdk:"machine_secrets"`
+	NotBefore           types.String        `tfsdk:"not_before"`
+	CrtTTL              types.String        `tfsdk:"crt_ttl"`
 	Endpoints           types.List          `tfsdk:"endpoints"`
 	Nodes               types.List          `tfsdk:"nodes"`
 	TalosConfig         types.String        `tfsdk:"talos_config"`
+	ClientConfiguration clientConfiguration `tfsdk:"client_configuration"`
 }
 
 // NewTalosClientConfigurationEphemeralResource implements the ephemeral.EphemeralResource interface.
@@ -38,7 +41,10 @@ func (r *talosClientConfigurationEphemeralResource) Metadata(_ context.Context, 
 
 func (r *talosClientConfigurationEphemeralResource) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Generate client configuration for a Talos cluster. This is an ephemeral resource that does not persist secrets in Terraform state.",
+		Description: "Generate client configuration for a Talos cluster from machine secrets. " +
+			"This is an ephemeral resource that does not persist secrets in Terraform state. " +
+			"The admin client certificate is generated with pinned timestamps so talos_config " +
+			"is byte-identical on every open as long as machine_secrets and not_before are unchanged.",
 		Attributes: map[string]schema.Attribute{
 			"cluster_name": schema.StringAttribute{
 				Required:    true,
@@ -47,24 +53,26 @@ func (r *talosClientConfigurationEphemeralResource) Schema(_ context.Context, _ 
 					stringvalidator.LengthAtLeast(1),
 				},
 			},
-			"client_configuration": schema.SingleNestedAttribute{
-				Attributes: map[string]schema.Attribute{
-					"ca_certificate": schema.StringAttribute{
-						Required:    true,
-						Description: "The client CA certificate",
-					},
-					"client_certificate": schema.StringAttribute{
-						Required:    true,
-						Description: "The client certificate",
-					},
-					"client_key": schema.StringAttribute{
-						Required:    true,
-						Sensitive:   true,
-						Description: "The client key",
-					},
+			"machine_secrets": machineSecretsSchemaAttribute(),
+			"not_before": schema.StringAttribute{
+				Optional: true,
+				Description: "RFC3339 timestamp to use as the NotBefore field of the generated admin client certificate. " +
+					"When set, the certificate validity starts at this time and ends at not_before + crt_ttl. " +
+					"Persist this value in a terraform_data resource so it is stable across plans and the " +
+					"generated talos_config is byte-identical on every open. " +
+					"When omitted, the certificate uses the OS CA's own NotBefore/NotAfter timestamps.",
+				Validators: []validator.String{
+					rfc3339Valid(),
 				},
-				Required:    true,
-				Description: "The client configuration data",
+			},
+			"crt_ttl": schema.StringAttribute{
+				Optional: true,
+				Description: "The lifetime of the generated admin client certificate as a Go duration string " +
+					"(e.g. \"8760h\" for 1 year, \"87600h\" for 10 years). Defaults to \"87600h\" (10 years). " +
+					"Only used when not_before is set; when not_before is omitted the cert uses the OS CA's NotAfter directly.",
+				Validators: []validator.String{
+					goDurationValid(),
+				},
 			},
 			"endpoints": schema.ListAttribute{
 				ElementType: types.StringType,
@@ -80,6 +88,26 @@ func (r *talosClientConfigurationEphemeralResource) Schema(_ context.Context, _ 
 				Computed:    true,
 				Description: "The generated client configuration",
 				Sensitive:   true,
+			},
+			"client_configuration": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"ca_certificate": schema.StringAttribute{
+						Computed:    true,
+						Description: "The client CA certificate",
+					},
+					"client_certificate": schema.StringAttribute{
+						Computed:    true,
+						Description: "The client certificate",
+					},
+					"client_key": schema.StringAttribute{
+						Computed:    true,
+						Sensitive:   true,
+						Description: "The client key",
+					},
+				},
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The generated client configuration data",
 			},
 		},
 	}
@@ -123,11 +151,34 @@ func (r *talosClientConfigurationEphemeralResource) Open(ctx context.Context, re
 		return
 	}
 
+	secretsBundle, err := machineSecretsToSecretsBundle(talosMachineSecretsResourceModelV1{
+		MachineSecrets: config.MachineSecrets,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to convert machine secrets to secrets bundle", err.Error())
+
+		return
+	}
+
+	notBefore, notAfter, tsErr := resolveClientConfigTimestamps(config.NotBefore.ValueString(), config.CrtTTL.ValueString(), secretsBundle.Certs.OS.Crt)
+	if tsErr != nil {
+		resp.Diagnostics.AddError(tsErr.summary, tsErr.detail)
+
+		return
+	}
+
+	cc, err := generateClientConfiguration(secretsBundle, config.ClusterName.ValueString(), notBefore, notAfter)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to generate client configuration", err.Error())
+
+		return
+	}
+
 	talosConfig, err := talosClientTFConfigToTalosClientConfig(
 		config.ClusterName.ValueString(),
-		config.ClientConfiguration.CA.ValueString(),
-		config.ClientConfiguration.Cert.ValueString(),
-		config.ClientConfiguration.Key.ValueString(),
+		cc.CA.ValueString(),
+		cc.Cert.ValueString(),
+		cc.Key.ValueString(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to generate talos config", err.Error())
@@ -145,18 +196,20 @@ func (r *talosClientConfigurationEphemeralResource) Open(ctx context.Context, re
 
 	talosConfigStringBytes, err := talosConfig.Bytes()
 	if err != nil {
-		resp.Diagnostics.AddError("failed to generate talos config", err.Error())
+		resp.Diagnostics.AddError("failed to serialize talos config", err.Error())
 
 		return
 	}
 
-	// Build result
 	result := talosClientConfigurationEphemeralResourceModel{
 		ClusterName:         config.ClusterName,
-		ClientConfiguration: config.ClientConfiguration,
+		MachineSecrets:      config.MachineSecrets,
+		NotBefore:           config.NotBefore,
+		CrtTTL:              config.CrtTTL,
 		Endpoints:           config.Endpoints,
 		Nodes:               config.Nodes,
 		TalosConfig:         basetypes.NewStringValue(string(talosConfigStringBytes)),
+		ClientConfiguration: cc,
 	}
 
 	diags = resp.Result.Set(ctx, &result)

--- a/pkg/talos/talos_client_configuration_ephemeral_resource_test.go
+++ b/pkg/talos/talos_client_configuration_ephemeral_resource_test.go
@@ -5,18 +5,20 @@
 package talos_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
-// TestAccTalosClientConfigurationEphemeralResource tests that the ephemeral
-// resource generates client configuration and can be chained from machine_secrets.
-func TestAccTalosClientConfigurationEphemeralResource(t *testing.T) {
+// TestAccTalosClientConfigurationEphemeralResourceFromMachineSecrets tests that the ephemeral
+// resource generates talos_config from machine_secrets.
+func TestAccTalosClientConfigurationEphemeralResourceFromMachineSecrets(t *testing.T) {
 	t.Parallel()
 
 	resource.UnitTest(t, resource.TestCase{
@@ -30,10 +32,10 @@ func TestAccTalosClientConfigurationEphemeralResource(t *testing.T) {
 ephemeral "talos_machine_secrets" "this" {}
 
 ephemeral "talos_client_configuration" "this" {
-	cluster_name         = "test-cluster"
-	client_configuration = ephemeral.talos_machine_secrets.this.client_configuration
-	endpoints            = ["10.0.0.1"]
-	nodes                = ["10.0.0.2"]
+	cluster_name    = "test-cluster"
+	machine_secrets = ephemeral.talos_machine_secrets.this.machine_secrets
+	endpoints       = ["10.0.0.1"]
+	nodes           = ["10.0.0.2"]
 }
 
 provider "echo" {
@@ -54,9 +56,9 @@ resource "echo" "test" {}
 	})
 }
 
-// TestAccTalosClientConfigurationEphemeralResourceChained tests chaining
-// ephemeral resources together: machine_secrets -> client_configuration.
-func TestAccTalosClientConfigurationEphemeralResourceChained(t *testing.T) {
+// TestAccTalosClientConfigurationEphemeralResourceCustomTTL tests that not_before + crt_ttl
+// are accepted and the resource opens without error.
+func TestAccTalosClientConfigurationEphemeralResourceCustomTTL(t *testing.T) {
 	t.Parallel()
 
 	resource.UnitTest(t, resource.TestCase{
@@ -70,20 +72,227 @@ func TestAccTalosClientConfigurationEphemeralResourceChained(t *testing.T) {
 ephemeral "talos_machine_secrets" "this" {}
 
 ephemeral "talos_client_configuration" "this" {
-	cluster_name         = "chained-cluster"
-	client_configuration = ephemeral.talos_machine_secrets.this.client_configuration
+	cluster_name    = "test-cluster"
+	machine_secrets = ephemeral.talos_machine_secrets.this.machine_secrets
+	not_before      = "2024-01-01T00:00:00Z"
+	crt_ttl         = "8760h"
 }
 
 provider "echo" {
 	data = {
-		has_talos_config = ephemeral.talos_client_configuration.this.talos_config != ""
+		talos_config = ephemeral.talos_client_configuration.this.talos_config
 	}
 }
 
 resource "echo" "test" {}
 `,
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue("echo.test", tfjsonpath.New("data").AtMapKey("has_talos_config"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue("echo.test", tfjsonpath.New("data").AtMapKey("talos_config"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+// TestAccTalosClientConfigurationEphemeralResourceCrtTTLInvalid tests that an invalid
+// crt_ttl value is rejected with an error.
+func TestAccTalosClientConfigurationEphemeralResourceCrtTTLInvalid(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithEcho,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+ephemeral "talos_machine_secrets" "this" {}
+
+ephemeral "talos_client_configuration" "this" {
+	cluster_name    = "test-cluster"
+	machine_secrets = ephemeral.talos_machine_secrets.this.machine_secrets
+	crt_ttl         = "not-a-duration"
+}
+
+provider "echo" {
+	data = {}
+}
+
+resource "echo" "test" {}
+`,
+				ExpectError: regexp.MustCompile(`invalid crt_ttl`),
+			},
+		},
+	})
+}
+
+// TestAccTalosClientConfigurationEphemeralResourceDeterminism tests that two opens with
+// identical inputs (CA-pinned, no not_before) produce byte-identical talos_config.
+func TestAccTalosClientConfigurationEphemeralResourceDeterminism(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+resource "talos_machine_secrets" "this" {}
+
+ephemeral "talos_client_configuration" "this" {
+	cluster_name    = "test-cluster"
+	machine_secrets = talos_machine_secrets.this.machine_secrets
+	endpoints       = ["10.0.0.1"]
+}
+
+provider "echo" {
+	data = {
+		talos_config = ephemeral.talos_client_configuration.this.talos_config
+	}
+}
+
+resource "echo" "test" {}
+`
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithEcho,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("echo.test", tfjsonpath.New("data").AtMapKey("talos_config"), knownvalue.NotNull()),
+				},
+			},
+			{
+				Config: cfg,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccTalosClientConfigurationEphemeralResourceDeterminismWithNotBefore tests that two
+// opens with a terraform_data-sourced not_before produce byte-identical talos_config.
+func TestAccTalosClientConfigurationEphemeralResourceDeterminismWithNotBefore(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+resource "talos_machine_secrets" "this" {}
+
+resource "terraform_data" "client_config_nbf" {
+	input = "2024-01-01T00:00:00Z"
+}
+
+ephemeral "talos_client_configuration" "this" {
+	cluster_name    = "test-cluster"
+	machine_secrets = talos_machine_secrets.this.machine_secrets
+	not_before      = terraform_data.client_config_nbf.output
+	crt_ttl         = "87600h"
+}
+
+provider "echo" {
+	data = {
+		talos_config = ephemeral.talos_client_configuration.this.talos_config
+	}
+}
+
+resource "echo" "test" {}
+`
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithEcho,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("echo.test", tfjsonpath.New("data").AtMapKey("talos_config"), knownvalue.NotNull()),
+				},
+			},
+			{
+				Config: cfg,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccTalosClientConfigurationEphemeralResourceInvalidNotBefore tests that an invalid
+// not_before is rejected with an error.
+func TestAccTalosClientConfigurationEphemeralResourceInvalidNotBefore(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithEcho,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+ephemeral "talos_machine_secrets" "this" {}
+
+ephemeral "talos_client_configuration" "this" {
+	cluster_name    = "test-cluster"
+	machine_secrets = ephemeral.talos_machine_secrets.this.machine_secrets
+	not_before      = "not-a-timestamp"
+}
+
+provider "echo" {
+	data = {}
+}
+
+resource "echo" "test" {}
+`,
+				ExpectError: regexp.MustCompile(`invalid not_before`),
+			},
+		},
+	})
+}
+
+// TestAccTalosClientConfigurationEphemeralResourceClientConfigurationOutput tests that
+// client_configuration is populated with ca_certificate, client_certificate, and client_key.
+func TestAccTalosClientConfigurationEphemeralResourceClientConfigurationOutput(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithEcho,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+ephemeral "talos_machine_secrets" "this" {}
+
+ephemeral "talos_client_configuration" "this" {
+	cluster_name    = "test-cluster"
+	machine_secrets = ephemeral.talos_machine_secrets.this.machine_secrets
+}
+
+provider "echo" {
+	data = {
+		ca_certificate     = ephemeral.talos_client_configuration.this.client_configuration.ca_certificate
+		client_certificate = ephemeral.talos_client_configuration.this.client_configuration.client_certificate
+		client_key         = ephemeral.talos_client_configuration.this.client_configuration.client_key
+	}
+}
+
+resource "echo" "test" {}
+`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("echo.test", tfjsonpath.New("data").AtMapKey("ca_certificate"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue("echo.test", tfjsonpath.New("data").AtMapKey("client_certificate"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue("echo.test", tfjsonpath.New("data").AtMapKey("client_key"), knownvalue.NotNull()),
 				},
 			},
 		},

--- a/pkg/talos/talos_image_factory_versions_data_source_test.go
+++ b/pkg/talos/talos_image_factory_versions_data_source_test.go
@@ -26,7 +26,7 @@ func TestAccTalosImageFactoryVersionsDataSource(t *testing.T) {
 			{
 				Config: testAccTalosImageFactoryVersionsDataSourceWithFilterConfig(),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownOutputValue("talos_version", knownvalue.StringExact("v1.12.4")),
+					statecheck.ExpectKnownOutputValue("talos_version", knownvalue.StringExact("v1.12.6")),
 				},
 			},
 		},

--- a/pkg/talos/util.go
+++ b/pkg/talos/util.go
@@ -6,9 +6,17 @@ package talos
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/sha256"
 	"crypto/tls"
+	stdlibx509 "crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net/url"
 	"strings"
 	"time"
@@ -28,6 +36,8 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/gendata"
+	"github.com/siderolabs/talos/pkg/machinery/role"
+	"golang.org/x/crypto/hkdf"
 )
 
 type machineConfigGenerateOptions struct { //nolint:govet
@@ -126,10 +136,6 @@ func GenerateInstallerImage() string {
 }
 
 func secretsBundleTomachineSecrets(secretsBundle *secrets.Bundle) (talosMachineSecretsResourceModelV1, error) {
-	if secretsBundle.Clock == nil {
-		secretsBundle.Clock = secrets.NewFixedClock(time.Now())
-	}
-
 	model := talosMachineSecretsResourceModelV1{
 		ID: types.StringValue("machine_secrets"),
 		MachineSecrets: machineSecrets{
@@ -174,23 +180,233 @@ func secretsBundleTomachineSecrets(secretsBundle *secrets.Bundle) (talosMachineS
 		model.MachineSecrets.Secrets.AESCBCEncryptionSecret = types.StringValue(secretsBundle.Secrets.AESCBCEncryptionSecret)
 	}
 
-	generateInput, err := generate.NewInput("", "", "", generate.WithSecretsBundle(secretsBundle))
+	cc, err := generateClientConfigurationWithTTL(secretsBundle, constants.TalosAPIDefaultCertificateValidityDuration)
 	if err != nil {
 		return model, err
 	}
 
-	talosConfig, err := generateInput.Talosconfig()
-	if err != nil {
-		return model, err
-	}
-
-	model.ClientConfiguration = clientConfiguration{
-		CA:   types.StringValue(talosConfig.Contexts[talosConfig.Context].CA),
-		Cert: types.StringValue(talosConfig.Contexts[talosConfig.Context].Crt),
-		Key:  types.StringValue(talosConfig.Contexts[talosConfig.Context].Key),
-	}
+	model.ClientConfiguration = cc
 
 	return model, nil
+}
+
+// generateClientConfigurationWithTTL generates a clientConfiguration with a TTL-based cert.
+// Used by the managed talos_machine_secrets resource which stores and renews certs in state.
+func generateClientConfigurationWithTTL(secretsBundle *secrets.Bundle, ttl time.Duration) (clientConfiguration, error) {
+	if secretsBundle.Clock == nil {
+		secretsBundle.Clock = secrets.NewFixedClock(time.Now())
+	}
+
+	clientcert, err := secretsBundle.GenerateTalosAPIClientCertificateWithTTL(role.MakeSet(role.Admin), ttl)
+	if err != nil {
+		return clientConfiguration{}, err
+	}
+
+	return clientConfiguration{
+		CA:   types.StringValue(bytesToBase64(secretsBundle.Certs.OS.Crt)),
+		Cert: types.StringValue(bytesToBase64(clientcert.Crt)),
+		Key:  types.StringValue(bytesToBase64(clientcert.Key)),
+	}, nil
+}
+
+// generateClientConfiguration generates a clientConfiguration from a secrets bundle.
+//
+// The admin client certificate and key are derived deterministically using HKDF
+// (RFC 5869) seeded from the OS CA private key and all cert-relevant inputs.
+// Same inputs always produce byte-identical output — no crypto/rand is used.
+//
+// Supports Ed25519 and ECDSA P-256 OS CA keys (Talos uses Ed25519 since v1.x).
+// Ed25519 signing is deterministic by design (RFC 8032); ECDSA uses RFC 6979.
+func generateClientConfiguration(secretsBundle *secrets.Bundle, clusterName string, notBefore, notAfter time.Time) (clientConfiguration, error) {
+	caCertBlock, _ := pem.Decode(secretsBundle.Certs.OS.Crt)
+	if caCertBlock == nil {
+		return clientConfiguration{}, fmt.Errorf("error decoding OS CA certificate PEM")
+	}
+
+	caCert, err := stdlibx509.ParseCertificate(caCertBlock.Bytes)
+	if err != nil {
+		return clientConfiguration{}, fmt.Errorf("error parsing OS CA certificate: %w", err)
+	}
+
+	caKeyBlock, _ := pem.Decode(secretsBundle.Certs.OS.Key)
+	if caKeyBlock == nil {
+		return clientConfiguration{}, fmt.Errorf("error decoding OS CA private key PEM")
+	}
+
+	info := fmt.Sprintf("talos-clientconfig:v1:%s:%d:%d", clusterName, notBefore.Unix(), notAfter.Unix())
+	deterministicReader := hkdf.New(sha256.New, secretsBundle.Certs.OS.Key, []byte("talos-clientconfig-v1"), []byte(info))
+
+	serialBytes := make([]byte, 16)
+	if _, err = deterministicReader.Read(serialBytes); err != nil {
+		return clientConfiguration{}, fmt.Errorf("error deriving serial number: %w", err)
+	}
+
+	template := &stdlibx509.Certificate{
+		SerialNumber: new(big.Int).SetBytes(serialBytes),
+		Subject: pkix.Name{
+			Organization: []string{"os:admin"},
+		},
+		NotBefore:   notBefore,
+		NotAfter:    notAfter,
+		KeyUsage:    stdlibx509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []stdlibx509.ExtKeyUsage{stdlibx509.ExtKeyUsageClientAuth},
+	}
+
+	var (
+		certDER      []byte
+		clientKeyPEM []byte
+	)
+
+	caKeyParsed, parseErr := parseCAPrivateKey(caKeyBlock)
+	if parseErr != nil {
+		return clientConfiguration{}, parseErr
+	}
+
+	switch caKey := caKeyParsed.(type) {
+	case ed25519.PrivateKey:
+		adminKeyBytes := make([]byte, ed25519.SeedSize)
+		if _, err = deterministicReader.Read(adminKeyBytes); err != nil {
+			return clientConfiguration{}, fmt.Errorf("error deriving admin key bytes: %w", err)
+		}
+
+		adminKey := ed25519.NewKeyFromSeed(adminKeyBytes)
+
+		// Ed25519 signing is deterministic per RFC 8032 — rand reader is unused.
+		certDER, err = stdlibx509.CreateCertificate(nil, template, caCert, adminKey.Public(), caKey)
+		if err != nil {
+			return clientConfiguration{}, fmt.Errorf("error signing admin certificate: %w", err)
+		}
+
+		adminKeyDER, marshalErr := stdlibx509.MarshalPKCS8PrivateKey(adminKey)
+		if marshalErr != nil {
+			return clientConfiguration{}, fmt.Errorf("error marshaling admin private key: %w", marshalErr)
+		}
+
+		clientKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: adminKeyDER})
+
+	case *ecdsa.PrivateKey:
+		adminKeyBytes := make([]byte, 32)
+		if _, err = deterministicReader.Read(adminKeyBytes); err != nil {
+			return clientConfiguration{}, fmt.Errorf("error deriving admin key bytes: %w", err)
+		}
+
+		adminKey, ecParseErr := ecdsa.ParseRawPrivateKey(elliptic.P256(), adminKeyBytes)
+		if ecParseErr != nil {
+			return clientConfiguration{}, fmt.Errorf("error parsing derived admin key: %w", ecParseErr)
+		}
+
+		caSigner := &deterministicECDSASigner{key: caKey}
+
+		certDER, err = stdlibx509.CreateCertificate(nil, template, caCert, &adminKey.PublicKey, caSigner)
+		if err != nil {
+			return clientConfiguration{}, fmt.Errorf("error signing admin certificate: %w", err)
+		}
+
+		adminKeyDER, marshalErr := stdlibx509.MarshalECPrivateKey(adminKey)
+		if marshalErr != nil {
+			return clientConfiguration{}, fmt.Errorf("error marshaling admin private key: %w", marshalErr)
+		}
+
+		clientKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: adminKeyDER})
+
+	default:
+		return clientConfiguration{}, fmt.Errorf("unsupported OS CA private key type: %T", caKeyParsed)
+	}
+
+	clientCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	return clientConfiguration{
+		CA:   types.StringValue(bytesToBase64(secretsBundle.Certs.OS.Crt)),
+		Cert: types.StringValue(bytesToBase64(clientCertPEM)),
+		Key:  types.StringValue(bytesToBase64(clientKeyPEM)),
+	}, nil
+}
+
+// parseCAPrivateKey parses a PEM block into either an ed25519.PrivateKey or *ecdsa.PrivateKey.
+func parseCAPrivateKey(block *pem.Block) (any, error) {
+	switch block.Type {
+	case "EC PRIVATE KEY":
+		key, err := stdlibx509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing OS CA private key: %w", err)
+		}
+
+		return key, nil
+
+	case "ED25519 PRIVATE KEY", "PRIVATE KEY":
+		parsed, err := stdlibx509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing OS CA private key: %w", err)
+		}
+
+		switch k := parsed.(type) {
+		case ed25519.PrivateKey:
+			return k, nil
+		case *ecdsa.PrivateKey:
+			return k, nil
+		default:
+			return nil, fmt.Errorf("unsupported OS CA private key type in PKCS#8: %T", parsed)
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported OS CA private key PEM type: %s", block.Type)
+	}
+}
+
+type clientConfigTimestampError struct {
+	summary string
+	detail  string
+}
+
+func (e *clientConfigTimestampError) Error() string { return e.detail }
+
+// resolveClientConfigTimestamps resolves notBefore/notAfter for the admin client certificate.
+// When notBeforeStr is non-empty it parses the RFC3339 timestamp and adds crtTTLStr (default 87600h).
+// When notBeforeStr is empty it reads the timestamps from the OS CA PEM.
+func resolveClientConfigTimestamps(notBeforeStr, crtTTLStr string, osCACert []byte) (notBefore, notAfter time.Time, tsErr *clientConfigTimestampError) {
+	if notBeforeStr != "" {
+		var err error
+
+		notBefore, err = time.Parse(time.RFC3339, notBeforeStr)
+		if err != nil {
+			return time.Time{}, time.Time{}, &clientConfigTimestampError{
+				summary: "invalid not_before",
+				detail:  fmt.Sprintf("unable to parse not_before %q as RFC3339: %s", notBeforeStr, err.Error()),
+			}
+		}
+
+		crtTTL := 87600 * time.Hour
+
+		if crtTTLStr != "" {
+			crtTTL, err = time.ParseDuration(crtTTLStr)
+			if err != nil {
+				return time.Time{}, time.Time{}, &clientConfigTimestampError{
+					summary: "invalid crt_ttl",
+					detail:  fmt.Sprintf("unable to parse crt_ttl %q: %s", crtTTLStr, err.Error()),
+				}
+			}
+		}
+
+		return notBefore, notBefore.Add(crtTTL), nil
+	}
+
+	block, _ := pem.Decode(osCACert)
+	if block == nil {
+		return time.Time{}, time.Time{}, &clientConfigTimestampError{
+			summary: "failed to parse Talos OS CA certificate",
+			detail:  "PEM block is nil",
+		}
+	}
+
+	caCert, err := stdlibx509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return time.Time{}, time.Time{}, &clientConfigTimestampError{
+			summary: "failed to parse Talos OS CA certificate",
+			detail:  err.Error(),
+		}
+	}
+
+	return caCert.NotBefore, caCert.NotAfter, nil
 }
 
 func machineSecretsToSecretsBundle(model talosMachineSecretsResourceModelV1) (*secrets.Bundle, error) {
@@ -339,6 +555,62 @@ func (v talosVersionValidator) Description(_ context.Context) string {
 }
 
 func (v talosVersionValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+type goDurationValidator struct{}
+
+func goDurationValid() goDurationValidator {
+	return goDurationValidator{}
+}
+
+func (v goDurationValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if _, err := time.ParseDuration(req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"invalid crt_ttl",
+			fmt.Sprintf("unable to parse duration %q: %s", req.ConfigValue.ValueString(), err.Error()),
+		)
+	}
+}
+
+func (v goDurationValidator) Description(_ context.Context) string {
+	return "Validates that the value is a valid Go duration string (e.g. \"8760h\", \"87600h\")"
+}
+
+func (v goDurationValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+type rfc3339Validator struct{}
+
+func rfc3339Valid() rfc3339Validator {
+	return rfc3339Validator{}
+}
+
+func (v rfc3339Validator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if _, err := time.Parse(time.RFC3339, req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"invalid not_before",
+			fmt.Sprintf("unable to parse not_before %q as RFC3339: %s", req.ConfigValue.ValueString(), err.Error()),
+		)
+	}
+}
+
+func (v rfc3339Validator) Description(_ context.Context) string {
+	return "must be a valid RFC3339 timestamp (e.g. \"2024-01-01T00:00:00Z\")"
+}
+
+func (v rfc3339Validator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 


### PR DESCRIPTION
## Problem

`ephemeral.talos_client_configuration` previously required the caller to pass
in a pre-generated `client_configuration` (CA cert, client cert, client key)
as **inputs** — typically sourced from `talos_machine_secrets` outputs — and
merely assembled them into a `talos_config` YAML. This caused two problems:

1. **Secrets flowed through Terraform state** via `talos_machine_secrets`,
   defeating the purpose of an ephemeral resource.
2. **Spurious diffs** — the client certificate bytes changed on every
   `talos_machine_secrets` refresh (random key, `time.Now()`-based timestamps),
   causing cascading updates in downstream resources storing `talos_config`
   (e.g. `vault_kv_secret_v2`).

The root cause is that `client_configuration` is a **derived value** — it is
just a cert signed by the Talos OS CA key, which is already present in
`machine_secrets`. There is no reason to persist it.

## Solution

Rewrite `ephemeral.talos_client_configuration` to accept `machine_secrets`
directly and generate both `talos_config` and `client_configuration` fresh on
every `Open()`, removing `client_configuration` as an input entirely.

Determinism is achieved via:
- **HKDF** (RFC 5869) to derive the admin private key and serial number from
  stable inputs (OS CA key, cluster name, timestamps)
- **Ed25519** signing is deterministic by design (RFC 8032); **ECDSA P-256**
  uses RFC 6979, implemented as a custom `crypto.Signer` to bypass Go 1.26's
  enforced random nonces
- Admin key constructed from HKDF bytes, bypassing random key generation

Two timestamp strategies:
- **CA-pinned** (`not_before` omitted): cert validity window taken from the OS CA
- **User-controlled** (`not_before` set via `terraform_data`): explicit `NotBefore` +
  `crt_ttl` so cert rotation is opt-in via taint

```hcl
resource "terraform_data" "client_config_nbf" {
  input = plantimestamp()
  lifecycle { ignore_changes = [input] }
}

ephemeral "talos_client_configuration" "this" {
  cluster_name    = "prod"
  machine_secrets = talos_machine_secrets.this.machine_secrets
  not_before      = terraform_data.client_config_nbf.output
  crt_ttl         = "87600h"
}
```

The managed `talos_machine_secrets` resource retains its existing 1-year
TTL-based cert with automatic renewal logic unchanged.

## Breaking change

The `client_configuration` **input** attribute is removed. This is acceptable —
`ephemeral.talos_client_configuration` was introduced in `v0.11.0-beta.1` and
`v0.11.0` final has not been released yet, so no stable-release users can have
adopted it.

`client_configuration` is now a **computed output** (mirrors the
`client_configuration` output of `talos_machine_secrets` for drop-in
downstream compatibility).