### PR TITLE
fix: handle unknown-whole-list config_patches on machine_configuration_apply

### DIFF
--- a/pkg/talos/talos_machine_configuration_apply_resource.go
+++ b/pkg/talos/talos_machine_configuration_apply_resource.go
@@ -74,7 +74,7 @@ type talosMachineConfigurationApplyResourceModelV1 struct { //nolint:govet
 	OnDestroy                   *onDestroyOptions     `tfsdk:"on_destroy"`
 	MachineConfiguration        types.String          `tfsdk:"machine_configuration"`
 	MachineConfigurationHash    types.String          `tfsdk:"machine_configuration_hash"`
-	ConfigPatches               []types.String        `tfsdk:"config_patches"`
+	ConfigPatches               types.List            `tfsdk:"config_patches"`
 	Timeouts                    timeouts.Value        `tfsdk:"timeouts"`
 }
 
@@ -299,11 +299,9 @@ func computeMachineConfiguration(state *talosMachineConfigurationApplyResourceMo
 		return "", fmt.Errorf("machine configuration input is null")
 	}
 
-	configPatches := make([]string, len(state.ConfigPatches))
-	for i, patch := range state.ConfigPatches {
-		if !patch.IsNull() {
-			configPatches[i] = patch.ValueString()
-		}
+	configPatches, err := configPatchesAsStrings(state.ConfigPatches)
+	if err != nil {
+		return "", err
 	}
 
 	patches, err := configpatcher.LoadPatches(configPatches)
@@ -322,6 +320,41 @@ func computeMachineConfiguration(state *talosMachineConfigurationApplyResourceMo
 	}
 
 	return string(cfgBytes), nil
+}
+
+// configPatchesAsStrings extracts a []string from a types.List of strings. It returns
+// an error if the list itself is unknown (caller cannot render in that case) or if any
+// element is unknown; null values are skipped. A null or empty list yields an empty slice.
+func configPatchesAsStrings(list types.List) ([]string, error) {
+	if list.IsUnknown() {
+		return nil, fmt.Errorf("config_patches list is unknown")
+	}
+
+	if list.IsNull() {
+		return nil, nil
+	}
+
+	elements := list.Elements()
+	result := make([]string, 0, len(elements))
+
+	for _, elem := range elements {
+		s, ok := elem.(basetypes.StringValue)
+		if !ok {
+			return nil, fmt.Errorf("config_patches element is not a string: %T", elem)
+		}
+
+		if s.IsUnknown() {
+			return nil, fmt.Errorf("config_patches element is unknown")
+		}
+
+		if s.IsNull() {
+			continue
+		}
+
+		result = append(result, s.ValueString())
+	}
+
+	return result, nil
 }
 
 // getClientConfiguration returns the effective client configuration,
@@ -1042,17 +1075,16 @@ func (p *talosMachineConfigurationApplyResource) ModifyPlan(ctx context.Context,
 	// If inputs are unknown (e.g., ephemeral values not yet resolved), the UseStateForUnknown
 	// plan modifier will preserve the prior state value to prevent drift
 	if !machineConfigInput.IsUnknown() && !machineConfigInput.IsNull() {
-		configPatches := make([]string, len(planState.ConfigPatches))
+		// If the whole config_patches list is unknown (e.g. `[for x in <unknown> : ...]`)
+		// or any element is unknown, we can't render — return so UseStateForUnknown wins.
+		if planState.ConfigPatches.IsUnknown() {
+			return
+		}
 
-		for i, patch := range planState.ConfigPatches {
-			// if any of the patches is unknown, return early
-			if patch.IsUnknown() {
-				return
-			}
-
-			if !patch.IsUnknown() && !patch.IsNull() {
-				configPatches[i] = patch.ValueString()
-			}
+		configPatches, err := configPatchesAsStrings(planState.ConfigPatches)
+		if err != nil {
+			// err is only returned when an element is Unknown — bail out like before.
+			return
 		}
 
 		patches, err := configpatcher.LoadPatches(configPatches)
@@ -1164,9 +1196,16 @@ func (p *talosMachineConfigurationApplyResource) UpgradeState(_ context.Context)
 					return
 				}
 
-				configPatches := make([]basetypes.StringValue, len(patches))
+				configPatchesElems := make([]attr.Value, len(patches))
 				for i, patch := range patches {
-					configPatches[i] = basetypes.NewStringValue(patch)
+					configPatchesElems[i] = basetypes.NewStringValue(patch)
+				}
+
+				configPatches, listDiags := basetypes.NewListValue(types.StringType, configPatchesElems)
+				resp.Diagnostics.Append(listDiags...)
+
+				if resp.Diagnostics.HasError() {
+					return
 				}
 
 				timeout, diag := basetypes.NewObjectValue(map[string]attr.Type{

--- a/pkg/talos/talos_machine_configuration_apply_resource_test.go
+++ b/pkg/talos/talos_machine_configuration_apply_resource_test.go
@@ -533,39 +533,29 @@ resource "talos_machine_configuration_apply" "this" {
 `, rName, cpuMode, gendata.VersionTag, isoURL)
 }
 
-// TestAccTalosMachineConfigurationApplyDetectsEphemeralInputChange verifies that when
-// the ephemeral talos_machine_configuration's rendered output changes between plans —
-// which is how a talos_version bump or any patch edit propagates in real workflows —
-// the apply resource surfaces the change as a plan diff.
+// TestAccTalosMachineConfigurationApplyConfigPatchesUnknownList is a regression test for
+// a model-type bug: config_patches is declared as []types.String in the resource model,
+// which cannot hold a whole-list-unknown value. This surfaces when config_patches is
+// derived from a for-expression over an unknown value (e.g. a data source response body),
+// producing:
 //
-// Before the fix, machine_configuration_input_wo is write-only (not persisted) and
-// setPlanMachineConfiguration explicitly nulls the computed machine_configuration when
-// WO inputs are used, so changes are invisible to state and the plan is empty. The
-// fix is to persist a content fingerprint (machine_configuration_hash) that differs
-// when the rendered config differs, regardless of whether the source was write-only.
+//	Received unknown value, however the target type cannot handle unknown values.
+//	Path: config_patches
+//	Target Type: []basetypes.StringValue
+//	Suggested Type: basetypes.ListValue
 //
-// A persistent talos_machine_secrets resource is used so the generated config is
-// deterministic between plans — the only delta is the disk path.
-func TestAccTalosMachineConfigurationApplyDetectsEphemeralInputChange(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-
+// The test uses terraform_data (a built-in resource) whose output attribute is unknown
+// until apply; feeding it through jsondecode + for produces a whole-list-unknown
+// config_patches during plan, which reproduces the failure without requiring libvirt.
+func TestAccTalosMachineConfigurationApplyConfigPatchesUnknownList(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_11_0),
 		},
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"libvirt": {
-				Source:            "dmacvicar/libvirt",
-				VersionConstraint: "= 0.8.3",
-			},
-		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTalosMachineConfigurationApplyDetectsEphemeralInputChangeConfig(rName, "/dev/vda"),
-			},
-			{
-				Config:             testAccTalosMachineConfigurationApplyDetectsEphemeralInputChangeConfig(rName, "/dev/vdb"),
+				Config:             testAccTalosMachineConfigurationApplyConfigPatchesUnknownListConfig(),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
@@ -573,97 +563,26 @@ func TestAccTalosMachineConfigurationApplyDetectsEphemeralInputChange(t *testing
 	})
 }
 
-func testAccTalosMachineConfigurationApplyDetectsEphemeralInputChangeConfig(rName, disk string) string {
-	cpuMode := cpuModeHostPassthrough
-	if os.Getenv("CI") != "" {
-		cpuMode = cpuModeHostModel
-	}
-
-	isoURL := fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso", gendata.VersionTag)
-
-	return fmt.Sprintf(`
-resource "talos_machine_secrets" "this" {}
-
-ephemeral "talos_machine_configuration" "this" {
-  cluster_name       = "test-cluster"
-  cluster_endpoint   = "https://${libvirt_domain.cp.network_interface[0].addresses[0]}:6443"
-  machine_type       = "controlplane"
-  machine_secrets    = talos_machine_secrets.this.machine_secrets
-  talos_version      = "%[3]s"
-  kubernetes_version = "1.32.2"
-
-  config_patches = [
-    yamlencode({
-      machine = {
-        install = {
-          disk = "%[5]s"
-        }
-      }
-    })
-  ]
-}
-
-resource "libvirt_volume" "cp" {
-  name = "%[1]s"
-  size = 6442450944
-}
-
-resource "libvirt_domain" "cp" {
-  name     = "%[1]s"
-  firmware = "/usr/share/OVMF/OVMF_CODE_4M.fd"
-  nvram {
-    file     = "/var/lib/libvirt/qemu/nvram/%[1]s_VARS.fd"
-    template = "/usr/share/OVMF/OVMF_VARS_4M.fd"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      cpu,
-      nvram,
-      disk["url"],
-    ]
-  }
-
-  cpu {
-    mode = "%[2]s"
-  }
-
-  console {
-    type        = "pty"
-    target_port = "0"
-  }
-
-  graphics {
-    type        = "vnc"
-    listen_type = "address"
-  }
-
-  disk {
-    url = "%[4]s"
-  }
-
-  disk {
-    volume_id = libvirt_volume.cp.id
-  }
-
-  boot_device {
-    dev = ["cdrom"]
-  }
-
-  network_interface {
-    network_name   = "default"
-    wait_for_lease = true
-  }
-
-  vcpu   = "2"
-  memory = "4096"
+func testAccTalosMachineConfigurationApplyConfigPatchesUnknownListConfig() string {
+	return `
+resource "terraform_data" "source" {
+  input = "[\"a\",\"b\"]"
 }
 
 resource "talos_machine_configuration_apply" "this" {
-  client_configuration_wo        = talos_machine_secrets.this.client_configuration
-  machine_configuration_input_wo = ephemeral.talos_machine_configuration.this.machine_configuration
-  node                           = libvirt_domain.cp.network_interface[0].addresses[0]
-  endpoint                       = libvirt_domain.cp.network_interface[0].addresses[0]
+  client_configuration = {
+    ca_certificate     = "fake-ca"
+    client_certificate = "fake-cert"
+    client_key         = "fake-key"
+  }
+  machine_configuration_input = "version: v1alpha1\nmachine:\n  type: controlplane\n"
+  node                        = "127.0.0.1"
+  endpoint                    = "127.0.0.1"
+  config_patches = [
+    for item in jsondecode(terraform_data.source.output) : yamlencode({
+      machine = { install = { disk = "/dev/${item}" } }
+    })
+  ]
 }
-`, rName, cpuMode, gendata.VersionTag, isoURL, disk)
+`
 }


### PR DESCRIPTION
## Problem

`talos_machine_configuration_apply.config_patches` crashes at plan/validate
when fed a list that is itself unknown-as-a-whole (distinct from a
known-length list with unknown elements, which worked). Minimal repro:

```hcl
resource "terraform_data" "source" {
  input = "[\"a\",\"b\"]"
}

resource "talos_machine_configuration_apply" "this" {
  # ...
  config_patches = [
    for item in jsondecode(terraform_data.source.output) : yamlencode({
      machine = { install = { disk = "/dev/${item}" } }
    })
  ]
}
```

```
Error: Value Conversion Error

  with talos_machine_configuration_apply.this,
  on ... line 25, in resource "talos_machine_configuration_apply" "this":
  25:   config_patches = [ ... ]

Received unknown value, however the target type cannot handle unknown values.
Use the corresponding `types` package type or a custom type that handles
unknown values.

Path: config_patches
Target Type: []basetypes.StringValue
Suggested Type: basetypes.ListValue
```

Real-world trigger: `config_patches = concat(..., [for doc in jsondecode(data.http.x.response_body).documents : yamlencode(doc)], ...)` — common when Talos machine-config patches are sourced from an HTTP data source (e.g. a NetBox network-config plugin) whose response body is unknown until the apply phase.

## Cause

`ConfigPatches` was declared as `[]types.String` in the resource model.
That type can represent a known list with unknown *elements*, but not a
list that is *itself* unknown — which is what Terraform produces from a
for-expression over an unknown source or a `concat` that includes an
unknown list. The framework suggests the fix in the error message.

## Solution

- Change `ConfigPatches []types.String` → `ConfigPatches types.List` in
  `talosMachineConfigurationApplyResourceModelV1`.
- Add a `configPatchesAsStrings` helper that extracts `[]string` from the
  list, returning an error if the list or any element is unknown. Used by
  `computeMachineConfiguration` (Create/Update path) and `ModifyPlan`.
- Adapt `ModifyPlan` to bail out early when the whole list is unknown so
  `UseStateForUnknown` preserves the prior `machine_configuration` value.
- Adapt the V0→V1 `UpgradeState` to build a `types.List` via
  `basetypes.NewListValue` instead of the old `[]basetypes.StringValue`.

`talos_machine_configuration_apply.config_patches` was the only outlier;
every other user-input `ListAttribute` model field in the provider
(`talos_cluster_health`, `talos_client_configuration`,
`talos_machine_configuration` data/ephemeral, extensions-versions filters)
already uses `types.List`.

## Test

New acc test `TestAccTalosMachineConfigurationApplyConfigPatchesUnknownList`
reproduces the crash with `terraform_data` (built-in) as the unknown
source — no libvirt needed. `PlanOnly + ExpectNonEmptyPlan: true`. Red
against the prior code, green after.

Existing acc tests rerun (all pass):
- `TestAccTalosMachineConfigurationApplyResource`
- `TestAccTalosMachineConfigurationApplyResourceAutoStaged`
- `TestAccTalosMachineConfigurationApplyWithEphemeralClientConfigWO`
- `TestAccTalosMachineConfigurationApplyResourceUpgradeWithResolvedApplyModeBug`
- `TestAccTalosMachineConfigurationApplyResourceUpgradeWithResolvedApplyModeFix`

The two upgrade tests specifically exercise the V0→V1 state migration with
`config_patches` populated, which validates the `UpgradeState` change.