### PR TITLE
fix(ephemeral): detect machine_configuration_input_wo changes via hash

### DIFF
--- a/docs/resources/machine_configuration_apply.md
+++ b/docs/resources/machine_configuration_apply.md
@@ -70,6 +70,7 @@ then a subsequent *terraform destroy* for the changes to take effect due to limi
 
 - `id` (String) This is a unique identifier for the machine
 - `machine_configuration` (String, Sensitive) The generated machine configuration after applying patches
+- `machine_configuration_hash` (String) SHA256 hex digest of the rendered machine configuration (input plus patches). Persisted in state so that changes to machine_configuration_input_wo — which is write-only and itself invisible to state — still surface as plan diffs.
 - `resolved_apply_mode` (String) The actual apply mode used. When apply_mode is 'staged_if_needing_reboot', shows the resolved mode ('auto' or 'staged') based on dry-run analysis. Equals apply_mode for other modes.
 
 <a id="nestedatt--client_configuration"></a>

--- a/pkg/talos/provider_test.go
+++ b/pkg/talos/provider_test.go
@@ -36,10 +36,15 @@ type dynamicConfig struct {
 	WithClusterHealth      bool
 }
 
+const (
+	cpuModeHostPassthrough = "host-passthrough"
+	cpuModeHostModel       = "host-model"
+)
+
 func (c *dynamicConfig) render() string {
-	cpuMode := "host-passthrough"
+	cpuMode := cpuModeHostPassthrough
 	if os.Getenv("CI") != "" {
-		cpuMode = "host-model"
+		cpuMode = cpuModeHostModel
 	}
 
 	c.CPUMode = cpuMode

--- a/pkg/talos/talos_machine_configuration_apply_resource.go
+++ b/pkg/talos/talos_machine_configuration_apply_resource.go
@@ -6,7 +6,9 @@ package talos
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -71,6 +73,7 @@ type talosMachineConfigurationApplyResourceModelV1 struct { //nolint:govet
 	MachineConfigurationInputWO types.String          `tfsdk:"machine_configuration_input_wo"`
 	OnDestroy                   *onDestroyOptions     `tfsdk:"on_destroy"`
 	MachineConfiguration        types.String          `tfsdk:"machine_configuration"`
+	MachineConfigurationHash    types.String          `tfsdk:"machine_configuration_hash"`
 	ConfigPatches               []types.String        `tfsdk:"config_patches"`
 	Timeouts                    timeouts.Value        `tfsdk:"timeouts"`
 }
@@ -207,6 +210,15 @@ func (p *talosMachineConfigurationApplyResource) Schema(ctx context.Context, _ r
 				Description: "The generated machine configuration after applying patches",
 				Computed:    true,
 				Sensitive:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"machine_configuration_hash": schema.StringAttribute{
+				Description: "SHA256 hex digest of the rendered machine configuration (input plus patches). " +
+					"Persisted in state so that changes to machine_configuration_input_wo — which is write-only " +
+					"and itself invisible to state — still surface as plan diffs.",
+				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -1085,12 +1097,17 @@ func (p *talosMachineConfigurationApplyResource) ModifyPlan(ctx context.Context,
 
 // setPlanMachineConfiguration sets the machine_configuration attribute in the plan.
 // When write-only inputs are used, it sets the value to null to avoid storing secrets in state.
+// It also always sets machine_configuration_hash — a SHA256 fingerprint of the rendered
+// config — so that changes to write-only inputs (invisible to state) surface as plan diffs.
 func (p *talosMachineConfigurationApplyResource) setPlanMachineConfiguration(
 	ctx context.Context,
 	resp *resource.ModifyPlanResponse,
 	planState *talosMachineConfigurationApplyResourceModelV1,
 	cfgBytes []byte,
 ) {
+	sum := sha256.Sum256(cfgBytes)
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("machine_configuration_hash"), hex.EncodeToString(sum[:]))...)
+
 	// When using write-only inputs (_wo variants), don't populate the computed
 	// machine_configuration to prevent secrets from being stored in state.
 	if !planState.MachineConfigurationInputWO.IsNull() {

--- a/pkg/talos/talos_machine_configuration_apply_resource_test.go
+++ b/pkg/talos/talos_machine_configuration_apply_resource_test.go
@@ -355,16 +355,18 @@ resource "talos_machine_configuration_apply" "staged_if_needing_reboot" {
 //
 // This test uses ephemeral talos_machine_secrets and talos_machine_configuration WITHOUT
 // persistence (not recommended for production - see docs/guides/using_ephemeral_resources.md).
-// This causes expected drift because ephemeral secrets regenerate on each evaluation.
+// Secrets regenerate on each Open, so the rendered machine configuration — and therefore
+// machine_configuration_hash — differs between plans. ExpectNonEmptyPlan is true to reflect
+// this documented anti-pattern; production usage should persist secrets in a secret manager,
+// which keeps the hash stable across runs.
 //
 // The test validates:
-// - Write-only attributes work correctly with ephemeral inputs
-// - Resource creation succeeds with ephemeral values
-// - Write-only attributes are not stored in state
-// - The apply completes without errors
-//
-// Note: Expected drift is due to non-persisted ephemeral secrets (documented anti-pattern),
-// not a bug in the provider. Production usage should persist secrets in a secret manager.
+//   - Write-only attributes work correctly with ephemeral inputs
+//   - Resource creation succeeds with ephemeral values
+//   - Write-only attributes are not stored in state
+//   - machine_configuration_hash IS populated in state (hash fingerprint, not a secret)
+//   - Hash drift surfaces when non-persisted ephemeral secrets regenerate (correct behavior
+//     that was previously hidden by the write-only invisibility to state)
 func TestAccTalosMachineConfigurationApplyWithEphemeralClientConfigWO(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
@@ -388,6 +390,8 @@ func TestAccTalosMachineConfigurationApplyWithEphemeralClientConfigWO(t *testing
 					resource.TestCheckResourceAttrSet("talos_machine_configuration_apply.this", "node"),
 					// machine_configuration should NOT be in state when using write-only inputs
 					resource.TestCheckNoResourceAttr("talos_machine_configuration_apply.this", "machine_configuration"),
+					// machine_configuration_hash IS in state — it's a SHA256 fingerprint, not a secret
+					resource.TestCheckResourceAttrSet("talos_machine_configuration_apply.this", "machine_configuration_hash"),
 					// client_configuration_wo should not be in state (write-only)
 					resource.TestCheckNoResourceAttr("talos_machine_configuration_apply.this", "client_configuration_wo"),
 					// machine_configuration_input_wo should not be in state (write-only)
@@ -397,9 +401,11 @@ func TestAccTalosMachineConfigurationApplyWithEphemeralClientConfigWO(t *testing
 					// machine_configuration_input should not be set (using WO variant)
 					resource.TestCheckNoResourceAttr("talos_machine_configuration_apply.this", "machine_configuration_input"),
 				),
-				// No drift expected when using ephemeral inputs with write-only attributes
-				// since machine_configuration is not stored in state
-				ExpectNonEmptyPlan: false,
+				// Drift on non-persisted ephemeral secrets: each Open regenerates secrets,
+				// which changes the rendered machine configuration, which changes the hash.
+				// This is the correct behavior for this anti-pattern; persist secrets in
+				// production and the hash stays stable.
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -426,9 +432,9 @@ resource "talos_machine_configuration_apply" "staged_if_needing_reboot" {
 }
 
 func testAccTalosMachineConfigurationApplyWithEphemeralClientConfigWOConfig(rName string) string {
-	cpuMode := "host-passthrough"
+	cpuMode := cpuModeHostPassthrough
 	if os.Getenv("CI") != "" {
-		cpuMode = "host-model"
+		cpuMode = cpuModeHostModel
 	}
 
 	isoURL := fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso", gendata.VersionTag)
@@ -525,4 +531,139 @@ resource "talos_machine_configuration_apply" "this" {
   endpoint                       = libvirt_domain.cp.network_interface[0].addresses[0]
 }
 `, rName, cpuMode, gendata.VersionTag, isoURL)
+}
+
+// TestAccTalosMachineConfigurationApplyDetectsEphemeralInputChange verifies that when
+// the ephemeral talos_machine_configuration's rendered output changes between plans —
+// which is how a talos_version bump or any patch edit propagates in real workflows —
+// the apply resource surfaces the change as a plan diff.
+//
+// Before the fix, machine_configuration_input_wo is write-only (not persisted) and
+// setPlanMachineConfiguration explicitly nulls the computed machine_configuration when
+// WO inputs are used, so changes are invisible to state and the plan is empty. The
+// fix is to persist a content fingerprint (machine_configuration_hash) that differs
+// when the rendered config differs, regardless of whether the source was write-only.
+//
+// A persistent talos_machine_secrets resource is used so the generated config is
+// deterministic between plans — the only delta is the disk path.
+func TestAccTalosMachineConfigurationApplyDetectsEphemeralInputChange(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"libvirt": {
+				Source:            "dmacvicar/libvirt",
+				VersionConstraint: "= 0.8.3",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTalosMachineConfigurationApplyDetectsEphemeralInputChangeConfig(rName, "/dev/vda"),
+			},
+			{
+				Config:             testAccTalosMachineConfigurationApplyDetectsEphemeralInputChangeConfig(rName, "/dev/vdb"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccTalosMachineConfigurationApplyDetectsEphemeralInputChangeConfig(rName, disk string) string {
+	cpuMode := cpuModeHostPassthrough
+	if os.Getenv("CI") != "" {
+		cpuMode = cpuModeHostModel
+	}
+
+	isoURL := fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso", gendata.VersionTag)
+
+	return fmt.Sprintf(`
+resource "talos_machine_secrets" "this" {}
+
+ephemeral "talos_machine_configuration" "this" {
+  cluster_name       = "test-cluster"
+  cluster_endpoint   = "https://${libvirt_domain.cp.network_interface[0].addresses[0]}:6443"
+  machine_type       = "controlplane"
+  machine_secrets    = talos_machine_secrets.this.machine_secrets
+  talos_version      = "%[3]s"
+  kubernetes_version = "1.32.2"
+
+  config_patches = [
+    yamlencode({
+      machine = {
+        install = {
+          disk = "%[5]s"
+        }
+      }
+    })
+  ]
+}
+
+resource "libvirt_volume" "cp" {
+  name = "%[1]s"
+  size = 6442450944
+}
+
+resource "libvirt_domain" "cp" {
+  name     = "%[1]s"
+  firmware = "/usr/share/OVMF/OVMF_CODE_4M.fd"
+  nvram {
+    file     = "/var/lib/libvirt/qemu/nvram/%[1]s_VARS.fd"
+    template = "/usr/share/OVMF/OVMF_VARS_4M.fd"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      cpu,
+      nvram,
+      disk["url"],
+    ]
+  }
+
+  cpu {
+    mode = "%[2]s"
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
+
+  disk {
+    url = "%[4]s"
+  }
+
+  disk {
+    volume_id = libvirt_volume.cp.id
+  }
+
+  boot_device {
+    dev = ["cdrom"]
+  }
+
+  network_interface {
+    network_name   = "default"
+    wait_for_lease = true
+  }
+
+  vcpu   = "2"
+  memory = "4096"
+}
+
+resource "talos_machine_configuration_apply" "this" {
+  client_configuration_wo        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input_wo = ephemeral.talos_machine_configuration.this.machine_configuration
+  node                           = libvirt_domain.cp.network_interface[0].addresses[0]
+  endpoint                       = libvirt_domain.cp.network_interface[0].addresses[0]
+}
+`, rName, cpuMode, gendata.VersionTag, isoURL, disk)
 }


### PR DESCRIPTION
Add a computed machine_configuration_hash attribute (SHA256 of the rendered config) so changes propagating through write-only inputs surface as plan diffs. Covered by a new two-step acc test.