### PR TITLE
feat: replace skip_kubernetes_checks with health_check_level option

### DIFF
--- a/docs/data-sources/cluster_health.md
+++ b/docs/data-sources/cluster_health.md
@@ -23,7 +23,7 @@ Waits for the Talos cluster to be healthy. Can be used as a dependency before ru
 
 ### Optional
 
-- `skip_kubernetes_checks` (Boolean) Skip Kubernetes component checks, this is useful to check if the nodes has finished booting up and kubelet is running. Default is false.
+- `health_check_level` (String) Health check level to perform. Options: 'full' (all checks), 'talos' (pre-boot sequence checks), 'k8s' (pre-boot + k8s readiness checks). Use 'k8s' when Talos has no CNI, as it will pass once Kubernetes components are healthy even if CNI is absent and the node is not Ready. Default is 'full'.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `worker_nodes` (List of String) List of worker nodes to check for health.
 

--- a/docs/ephemeral-resources/cluster_health.md
+++ b/docs/ephemeral-resources/cluster_health.md
@@ -23,7 +23,7 @@ Checks the health of a Talos cluster. This is an ephemeral resource that does no
 
 ### Optional
 
-- `skip_kubernetes_checks` (Boolean) Skip Kubernetes component checks, this is useful to check if the nodes has finished booting up and kubelet is running. Default is false.
+- `health_check_level` (String) Health check level to perform. Options: 'full' (all checks), 'talos' (pre-boot sequence checks), 'k8s' (pre-boot + k8s readiness checks). Use 'k8s' when Talos has no CNI, as it will pass once Kubernetes components are healthy even if CNI is absent and the node is not Ready. Default is 'full'.
 - `timeout` (String) Timeout for the health check. Defaults to 10m. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'.
 - `worker_nodes` (List of String) List of worker nodes to check for health.
 

--- a/examples/ephemeral-resources/basic/main.tf
+++ b/examples/ephemeral-resources/basic/main.tf
@@ -107,11 +107,11 @@ resource "talos_machine_bootstrap" "this" {
 
 # Wait for cluster to be healthy (ephemeral — doesn't leak secrets to state).
 ephemeral "talos_cluster_health" "this" {
-  client_configuration   = ephemeral.talos_client_configuration.this.client_configuration
-  endpoints              = ["10.5.0.2"]
-  control_plane_nodes    = ["10.5.0.2"]
-  worker_nodes           = []
-  skip_kubernetes_checks = false
+  client_configuration = ephemeral.talos_client_configuration.this.client_configuration
+  endpoints            = ["10.5.0.2"]
+  control_plane_nodes  = ["10.5.0.2"]
+  worker_nodes         = []
+  health_check_level   = "full"
 
   depends_on = [
     talos_machine_bootstrap.this

--- a/pkg/talos/talos_cluster_health_data_source.go
+++ b/pkg/talos/talos_cluster_health_data_source.go
@@ -12,8 +12,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/siderolabs/talos/pkg/cluster"
@@ -28,13 +30,13 @@ type talosClusterHealthDataSource struct{}
 var _ datasource.DataSource = &talosClusterHealthDataSource{}
 
 type talosClusterHealthDataSourceModelV0 struct {
-	ID                   types.String        `tfsdk:"id"`
-	Endpoints            types.List          `tfsdk:"endpoints"`
-	ControlPlaneNodes    types.List          `tfsdk:"control_plane_nodes"`
-	WorkerNodes          types.List          `tfsdk:"worker_nodes"`
-	ClientConfiguration  clientConfiguration `tfsdk:"client_configuration"`
-	Timeouts             timeouts.Value      `tfsdk:"timeouts"`
-	SkipKubernetesChecks types.Bool          `tfsdk:"skip_kubernetes_checks"`
+	ID                  types.String        `tfsdk:"id"`
+	Endpoints           types.List          `tfsdk:"endpoints"`
+	ControlPlaneNodes   types.List          `tfsdk:"control_plane_nodes"`
+	WorkerNodes         types.List          `tfsdk:"worker_nodes"`
+	ClientConfiguration clientConfiguration `tfsdk:"client_configuration"`
+	Timeouts            timeouts.Value      `tfsdk:"timeouts"`
+	HealthCheckLevel    types.String        `tfsdk:"health_check_level"`
 }
 
 type clusterNodes struct {
@@ -127,9 +129,13 @@ func (d *talosClusterHealthDataSource) Schema(ctx context.Context, _ datasource.
 				ElementType: types.StringType,
 				Description: "List of worker nodes to check for health.",
 			},
-			"skip_kubernetes_checks": schema.BoolAttribute{
+			"health_check_level": schema.StringAttribute{
 				Optional:    true,
-				Description: "Skip Kubernetes component checks, this is useful to check if the nodes has finished booting up and kubelet is running. Default is false.",
+				Computed:    true,
+				Description: "Health check level to perform. Options: 'full' (all checks), 'talos' (pre-boot sequence checks), 'k8s' (pre-boot + k8s readiness checks). Use 'k8s' when Talos has no CNI, as it will pass once Kubernetes components are healthy even if CNI is absent and the node is not Ready. Default is 'full'.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("full", "talos", "k8s"),
+				},
 			},
 			"client_configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
@@ -249,10 +255,19 @@ func (d *talosClusterHealthDataSource) Read(ctx context.Context, req datasource.
 
 	reporter := newReporter()
 
-	checks := check.PreBootSequenceChecks()
+	var checks []check.ClusterCheck
+	healthCheckLevel := state.HealthCheckLevel.ValueString()
+	if healthCheckLevel == "" {
+		healthCheckLevel = "full"
+	}
 
-	if !state.SkipKubernetesChecks.ValueBool() {
+	switch healthCheckLevel {
+	case "full":
 		checks = check.DefaultClusterChecks()
+	case "talos":
+		checks = check.PreBootSequenceChecks()
+	case "k8s":
+		checks = slices.Concat(check.PreBootSequenceChecks(), check.K8sComponentsReadinessChecks())
 	}
 
 	if err := check.Wait(checkCtx, &clusterState, checks, reporter); err != nil {

--- a/pkg/talos/talos_cluster_health_ephemeral_resource.go
+++ b/pkg/talos/talos_cluster_health_ephemeral_resource.go
@@ -7,11 +7,14 @@ package talos
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/siderolabs/talos/pkg/cluster"
 	"github.com/siderolabs/talos/pkg/cluster/check"
@@ -24,12 +27,12 @@ var _ ephemeral.EphemeralResource = &talosClusterHealthEphemeralResource{}
 type talosClusterHealthEphemeralResource struct{}
 
 type talosClusterHealthEphemeralResourceModel struct {
-	ClientConfiguration  clientConfiguration `tfsdk:"client_configuration"`
-	Endpoints            types.List          `tfsdk:"endpoints"`
-	ControlPlaneNodes    types.List          `tfsdk:"control_plane_nodes"`
-	WorkerNodes          types.List          `tfsdk:"worker_nodes"`
-	Timeout              types.String        `tfsdk:"timeout"`
-	SkipKubernetesChecks types.Bool          `tfsdk:"skip_kubernetes_checks"`
+	ClientConfiguration clientConfiguration `tfsdk:"client_configuration"`
+	Endpoints           types.List          `tfsdk:"endpoints"`
+	ControlPlaneNodes   types.List          `tfsdk:"control_plane_nodes"`
+	WorkerNodes         types.List          `tfsdk:"worker_nodes"`
+	Timeout             types.String        `tfsdk:"timeout"`
+	HealthCheckLevel    types.String        `tfsdk:"health_check_level"`
 }
 
 type healthReporter struct {
@@ -82,9 +85,13 @@ func (r *talosClusterHealthEphemeralResource) Schema(_ context.Context, _ epheme
 				ElementType: types.StringType,
 				Description: "List of worker nodes to check for health.",
 			},
-			"skip_kubernetes_checks": schema.BoolAttribute{
+			"health_check_level": schema.StringAttribute{
 				Optional:    true,
-				Description: "Skip Kubernetes component checks, this is useful to check if the nodes has finished booting up and kubelet is running. Default is false.",
+				Computed:    true,
+				Description: "Health check level to perform. Options: 'full' (all checks), 'talos' (pre-boot sequence checks), 'k8s' (pre-boot + k8s readiness checks). Use 'k8s' when Talos has no CNI, as it will pass once Kubernetes components are healthy even if CNI is absent and the node is not Ready. Default is 'full'.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("full", "talos", "k8s"),
+				},
 			},
 			"client_configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
@@ -212,10 +219,19 @@ func (r *talosClusterHealthEphemeralResource) Open(ctx context.Context, req ephe
 
 	reporter := newHealthReporter()
 
-	checks := check.PreBootSequenceChecks()
+	var checks []check.ClusterCheck
+	healthCheckLevel := config.HealthCheckLevel.ValueString()
+	if healthCheckLevel == "" {
+		healthCheckLevel = "full"
+	}
 
-	if !config.SkipKubernetesChecks.ValueBool() {
+	switch healthCheckLevel {
+	case "full":
 		checks = check.DefaultClusterChecks()
+	case "talos":
+		checks = check.PreBootSequenceChecks()
+	case "k8s":
+		checks = slices.Concat(check.PreBootSequenceChecks(), check.K8sComponentsReadinessChecks())
 	}
 
 	if err := check.Wait(checkCtx, &clusterState, checks, reporter); err != nil {


### PR DESCRIPTION
Replace `skip_kubernetes_checks` boolean with a new `health_check_level` option for cluster health checks.

The health check was modified in #186 to fix #183. It later suffered a "[regression](https://xkcd.com/1172/)" in #312 as the original change was intended to solve the scenario in which no CNI is installed by default and signal Terraform when to proceed with installing a CNI.

The new `health_check_level` allows for the behaviour of `skip_kubernetes_checks` to remain available but also adds a `k8s` check specifically for the CNI installation scenario (naming of the leves is open to discussion)

> [!IMPORTANT]  
> This is a breaking change for users who previously used `skip_kubernetes_checks`. They should migrate to `health_check_level`