### PR TITLE
fix(talos_cluster): add control_plane_nodes to fix HA bootstrap

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -2,12 +2,12 @@
 page_title: "talos_cluster Resource - talos"
 subcategory: ""
 description: |-
-  Manages a Talos cluster: bootstraps etcd and tracks Kubernetes version. Use talos_cluster_kubeconfig to retrieve credentials.
+  Manages a Talos cluster: bootstraps etcd and tracks Kubernetes version. This resource completes once the Talos layer (etcd, apid, kubelet) is healthy across all control plane nodes. It does not wait for Kubernetes components to be ready — use talos_cluster_health for that before depending on the Kubernetes API.
 ---
 
 # talos_cluster (Resource)
 
-Manages a Talos cluster: bootstraps etcd and tracks Kubernetes version. Use talos_cluster_kubeconfig to retrieve credentials.
+Manages a Talos cluster: bootstraps etcd and tracks Kubernetes version. This resource completes once the Talos layer (etcd, apid, kubelet) is healthy across all control plane nodes. It does not wait for Kubernetes components to be ready — use talos_cluster_health for that before depending on the Kubernetes API.
 
 ## Example Usage
 
@@ -56,7 +56,7 @@ data "talos_cluster_kubeconfig" "this" {
 ### Required
 
 - `kubernetes_version` (String) Desired Kubernetes version (e.g. `v1.32.0`). Changing this triggers a rolling upgrade.
-- `node` (String) The IP address or hostname of a control plane node.
+- `node` (String) The IP address or hostname of the control plane node to bootstrap etcd on.
 
 ### Optional
 
@@ -64,6 +64,7 @@ data "talos_cluster_kubeconfig" "this" {
 
 - `client_configuration` (Attributes) The Talos client configuration. Use client_configuration_wo when using ephemeral resources. (see [below for nested schema](#nestedatt--client_configuration))
 - `client_configuration_wo` (Attributes, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only variant of client_configuration for use with ephemeral resources. Requires Terraform 1.11+. (see [below for nested schema](#nestedatt--client_configuration_wo))
+- `control_plane_nodes` (List of String) List of all control plane node IPs used for etcd health checks. Defaults to [node]. Required for HA clusters where all control plane IPs must be listed.
 - `endpoint` (String) The endpoint to use when connecting to the node. Defaults to node.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/pkg/talos/talos_cluster_resource.go
+++ b/pkg/talos/talos_cluster_resource.go
@@ -7,13 +7,17 @@ package talos
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -43,6 +47,7 @@ var (
 type talosClusterResourceModel struct {
 	ClientConfiguration   basetypes.ObjectValue `tfsdk:"client_configuration"`
 	ClientConfigurationWO basetypes.ObjectValue `tfsdk:"client_configuration_wo"`
+	ControlPlaneNodes     types.List            `tfsdk:"control_plane_nodes"`
 	Endpoint              types.String          `tfsdk:"endpoint"`
 	ID                    types.String          `tfsdk:"id"`
 	KubernetesVersion     types.String          `tfsdk:"kubernetes_version"`
@@ -61,7 +66,9 @@ func (r *talosClusterResource) Metadata(_ context.Context, req resource.Metadata
 
 func (r *talosClusterResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Manages a Talos cluster: bootstraps etcd and tracks Kubernetes version. Use talos_cluster_kubeconfig to retrieve credentials.",
+		Description: "Manages a Talos cluster: bootstraps etcd and tracks Kubernetes version. " +
+			"This resource completes once the Talos layer (etcd, apid, kubelet) is healthy across all control plane nodes. " +
+			"It does not wait for Kubernetes components to be ready — use talos_cluster_health for that before depending on the Kubernetes API.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -71,7 +78,16 @@ func (r *talosClusterResource) Schema(ctx context.Context, _ resource.SchemaRequ
 			},
 			"node": schema.StringAttribute{
 				Required:    true,
-				Description: "The IP address or hostname of a control plane node.",
+				Description: "The IP address or hostname of the control plane node to bootstrap etcd on.",
+			},
+			"control_plane_nodes": schema.ListAttribute{
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "List of all control plane node IPs used for etcd health checks. Defaults to [node]. Required for HA clusters where all control plane IPs must be listed.",
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"endpoint": schema.StringAttribute{
 				Optional:    true,
@@ -160,6 +176,20 @@ func (r *talosClusterResource) ValidateConfig(ctx context.Context, req resource.
 			"Only one of client_configuration or client_configuration_wo can be set, not both.",
 		)
 	}
+
+	if !cfg.ControlPlaneNodes.IsNull() && !cfg.Node.IsNull() && !cfg.Node.IsUnknown() {
+		var nodes []string
+
+		if diags := cfg.ControlPlaneNodes.ElementsAs(ctx, &nodes, false); !diags.HasError() {
+			if !slices.Contains(nodes, cfg.Node.ValueString()) {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("control_plane_nodes"),
+					"node not in control_plane_nodes",
+					fmt.Sprintf("node %q must be included in control_plane_nodes", cfg.Node.ValueString()),
+				)
+			}
+		}
+	}
 }
 
 func (r *talosClusterResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
@@ -185,6 +215,11 @@ func (r *talosClusterResource) ModifyPlan(ctx context.Context, req resource.Modi
 
 	if cfgFromConfig.Endpoint.IsNull() && !plan.Node.IsUnknown() && !plan.Node.IsNull() {
 		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("endpoint"), plan.Node)...)
+	}
+
+	if cfgFromConfig.ControlPlaneNodes.IsNull() && !plan.Node.IsUnknown() && !plan.Node.IsNull() {
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("control_plane_nodes"),
+			types.ListValueMust(types.StringType, []attr.Value{plan.Node}))...)
 	}
 }
 
@@ -235,7 +270,15 @@ func (r *talosClusterResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	if err = talosClusterWaitForK8s(ctxDeadline, endpoint, plan.Node.ValueString(), talosConfig); err != nil {
+	var controlPlaneNodes []string
+
+	resp.Diagnostics.Append(plan.ControlPlaneNodes.ElementsAs(ctx, &controlPlaneNodes, true)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err = talosClusterWaitForK8s(ctxDeadline, endpoint, controlPlaneNodes, talosConfig); err != nil {
 		resp.Diagnostics.AddError("error waiting for cluster health", err.Error())
 
 		return
@@ -343,7 +386,7 @@ func talosClusterBootstrap(ctx context.Context, endpoint, node string, talosConf
 }
 
 // talosClusterWaitForK8s waits for the cluster to pass all default health checks.
-func talosClusterWaitForK8s(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config) error {
+func talosClusterWaitForK8s(ctx context.Context, endpoint string, controlPlaneNodes []string, talosConfig *clientconfig.Config) error {
 	c, err := client.New(ctx, client.WithConfig(talosConfig), client.WithEndpoints(endpoint))
 	if err != nil {
 		return err
@@ -354,7 +397,7 @@ func talosClusterWaitForK8s(ctx context.Context, endpoint, node string, talosCon
 	clientProvider := &cluster.ConfigClientProvider{DefaultClient: c}
 	defer clientProvider.Close() //nolint:errcheck
 
-	nodeInfos, err := newClusterNodes([]string{node}, nil)
+	nodeInfos, err := newClusterNodes(controlPlaneNodes, nil)
 	if err != nil {
 		return err
 	}
@@ -369,7 +412,7 @@ func talosClusterWaitForK8s(ctx context.Context, endpoint, node string, talosCon
 		Info:           nodeInfos,
 	}
 
-	return check.Wait(ctx, &clusterState, check.DefaultClusterChecks(), newReporter())
+	return check.Wait(ctx, &clusterState, check.PreBootSequenceChecks(), newReporter())
 }
 
 // talosClusterUpgradeKubernetes runs a rolling Kubernetes upgrade via the talos cluster package.

--- a/pkg/talos/talos_cluster_resource_test.go
+++ b/pkg/talos/talos_cluster_resource_test.go
@@ -85,6 +85,38 @@ func TestAccTalosCluster_upgrade(t *testing.T) {
 	})
 }
 
+// TestAccTalosCluster_bootstrapHA exercises bootstrapping a three-control-plane HA
+// cluster via talos_cluster. This is the red-phase test for the bug reported in
+// https://github.com/siderolabs/terraform-provider-talos/issues/339: the resource
+// times out because talosClusterWaitForK8s only supplies the bootstrap node IP to
+// the etcd membership check, which fails when etcd has three members.
+func TestAccTalosCluster_bootstrapHA(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"libvirt": {
+				Source:            "dmacvicar/libvirt",
+				VersionConstraint: "= 0.8.3",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTalosClusterHAConfig(rName, gendata.VersionTag, "v1.35.4"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("talos_cluster.this", "id"),
+				),
+			},
+			// second apply must produce an empty plan
+			{
+				Config:   testAccTalosClusterHAConfig(rName, gendata.VersionTag, "v1.35.4"),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccTalosClusterConfig(rName, talosVersion, k8sVersion string) string {
 	cpuMode := cpuModeHostPassthrough
 	if os.Getenv("CI") != "" {
@@ -186,6 +218,270 @@ resource "talos_machine_configuration_apply" "this" {
 resource "talos_cluster" "this" {
   depends_on           = [talos_machine_configuration_apply.this]
   node                 = libvirt_domain.cp.network_interface[0].addresses[0]
+  client_configuration = talos_machine_secrets.this.client_configuration
+  kubernetes_version   = %[5]q
+
+  timeouts = {
+    create = "20m"
+    update = "30m"
+  }
+}
+
+data "talos_cluster_health" "this" {
+  depends_on           = [talos_cluster.this]
+  client_configuration = talos_machine_secrets.this.client_configuration
+  endpoints            = libvirt_domain.cp.network_interface[0].addresses
+  control_plane_nodes  = libvirt_domain.cp.network_interface[0].addresses
+
+  timeouts = {
+    read = "20m"
+  }
+}
+`, rName, cpuMode, isoURL, talosVersion, k8sVersion)
+}
+
+func testAccTalosClusterHAConfig(rName, talosVersion, k8sVersion string) string {
+	cpuMode := cpuModeHostPassthrough
+	if os.Getenv("CI") != "" {
+		cpuMode = cpuModeHostModel
+	}
+
+	isoURL := fmt.Sprintf(
+		"https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso",
+		talosVersion,
+	)
+
+	return fmt.Sprintf(`
+resource "talos_machine_secrets" "this" {}
+
+data "talos_machine_configuration" "cp" {
+  cluster_name       = "test"
+  cluster_endpoint   = "https://${libvirt_domain.cp_01.network_interface[0].addresses[0]}:6443"
+  machine_type       = "controlplane"
+  machine_secrets    = talos_machine_secrets.this.machine_secrets
+  talos_version      = %[4]q
+  kubernetes_version = %[5]q
+  docs               = false
+  examples           = false
+  config_patches = [
+    yamlencode({
+      machine = {
+        install = {
+          disk  = "/dev/vda"
+          image = "ghcr.io/siderolabs/installer:%[4]s"
+        }
+      }
+    })
+  ]
+}
+
+resource "libvirt_volume" "cp_01" {
+  name = "%[1]s-01"
+  size = 6442450944
+}
+
+resource "libvirt_volume" "cp_02" {
+  name = "%[1]s-02"
+  size = 6442450944
+}
+
+resource "libvirt_volume" "cp_03" {
+  name = "%[1]s-03"
+  size = 6442450944
+}
+
+resource "libvirt_domain" "cp_01" {
+  name     = "%[1]s-01"
+  firmware = "/usr/share/OVMF/OVMF_CODE_4M.fd"
+
+  nvram {
+    file     = "/var/lib/libvirt/qemu/nvram/%[1]s-01_VARS.fd"
+    template = "/usr/share/OVMF/OVMF_VARS_4M.fd"
+  }
+
+  lifecycle {
+    ignore_changes = [cpu, nvram, disk["url"]]
+  }
+
+  cpu {
+    mode = %[2]q
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
+
+  disk {
+    url = %[3]q
+  }
+
+  disk {
+    volume_id = libvirt_volume.cp_01.id
+  }
+
+  boot_device {
+    dev = ["cdrom"]
+  }
+
+  network_interface {
+    network_name   = "default"
+    wait_for_lease = true
+  }
+
+  vcpu   = "2"
+  memory = "4096"
+}
+
+resource "libvirt_domain" "cp_02" {
+  name     = "%[1]s-02"
+  firmware = "/usr/share/OVMF/OVMF_CODE_4M.fd"
+
+  nvram {
+    file     = "/var/lib/libvirt/qemu/nvram/%[1]s-02_VARS.fd"
+    template = "/usr/share/OVMF/OVMF_VARS_4M.fd"
+  }
+
+  lifecycle {
+    ignore_changes = [cpu, nvram, disk["url"]]
+  }
+
+  cpu {
+    mode = %[2]q
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
+
+  disk {
+    url = %[3]q
+  }
+
+  disk {
+    volume_id = libvirt_volume.cp_02.id
+  }
+
+  boot_device {
+    dev = ["cdrom"]
+  }
+
+  network_interface {
+    network_name   = "default"
+    wait_for_lease = true
+  }
+
+  vcpu   = "2"
+  memory = "4096"
+}
+
+resource "libvirt_domain" "cp_03" {
+  name     = "%[1]s-03"
+  firmware = "/usr/share/OVMF/OVMF_CODE_4M.fd"
+
+  nvram {
+    file     = "/var/lib/libvirt/qemu/nvram/%[1]s-03_VARS.fd"
+    template = "/usr/share/OVMF/OVMF_VARS_4M.fd"
+  }
+
+  lifecycle {
+    ignore_changes = [cpu, nvram, disk["url"]]
+  }
+
+  cpu {
+    mode = %[2]q
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
+
+  disk {
+    url = %[3]q
+  }
+
+  disk {
+    volume_id = libvirt_volume.cp_03.id
+  }
+
+  boot_device {
+    dev = ["cdrom"]
+  }
+
+  network_interface {
+    network_name   = "default"
+    wait_for_lease = true
+  }
+
+  vcpu   = "2"
+  memory = "4096"
+}
+
+resource "talos_machine" "cp_01" {
+  node                  = libvirt_domain.cp_01.network_interface[0].addresses[0]
+  endpoint              = libvirt_domain.cp_01.network_interface[0].addresses[0]
+  client_configuration  = talos_machine_secrets.this.client_configuration
+  machine_configuration = data.talos_machine_configuration.cp.machine_configuration
+  image                 = "ghcr.io/siderolabs/installer:%[4]s"
+  drain_on_upgrade      = false
+
+  timeouts = {
+    create = "20m"
+    update = "60m"
+    delete = "5m"
+  }
+}
+
+resource "talos_machine" "cp_02" {
+  node                  = libvirt_domain.cp_02.network_interface[0].addresses[0]
+  endpoint              = libvirt_domain.cp_02.network_interface[0].addresses[0]
+  client_configuration  = talos_machine_secrets.this.client_configuration
+  machine_configuration = data.talos_machine_configuration.cp.machine_configuration
+  image                 = "ghcr.io/siderolabs/installer:%[4]s"
+  drain_on_upgrade      = false
+
+  timeouts = {
+    create = "20m"
+    update = "60m"
+    delete = "5m"
+  }
+}
+
+resource "talos_machine" "cp_03" {
+  node                  = libvirt_domain.cp_03.network_interface[0].addresses[0]
+  endpoint              = libvirt_domain.cp_03.network_interface[0].addresses[0]
+  client_configuration  = talos_machine_secrets.this.client_configuration
+  machine_configuration = data.talos_machine_configuration.cp.machine_configuration
+  image                 = "ghcr.io/siderolabs/installer:%[4]s"
+  drain_on_upgrade      = false
+
+  timeouts = {
+    create = "20m"
+    update = "60m"
+    delete = "5m"
+  }
+}
+
+resource "talos_cluster" "this" {
+  node                 = talos_machine.cp_01.node
+  control_plane_nodes  = [talos_machine.cp_01.node, talos_machine.cp_02.node, talos_machine.cp_03.node]
   client_configuration = talos_machine_secrets.this.client_configuration
   kubernetes_version   = %[5]q
 


### PR DESCRIPTION
talosClusterWaitForK8s was passing only the bootstrap node IP to
newClusterNodes, causing EtcdControlPlaneNodesAssertion and
EtcdConsistentAssertion to fail on HA clusters where etcd has
three members but only one IP was provided.

Add a required control_plane_nodes list attribute so all CP node IPs
are supplied to the health checks. Switch from DefaultClusterChecks to
PreBootSequenceChecks so talos_cluster gates on Talos layer readiness
only; full Kubernetes health validation belongs in talos_cluster_health.

Fixes https://github.com/siderolabs/terraform-provider-talos/issues/339