### PR TITLE
fix(on_destroy): use types.Bool to handle unknown values in on_destro…

### DIFF
--- a/pkg/talos/talos_machine_configuration_apply_resource.go
+++ b/pkg/talos/talos_machine_configuration_apply_resource.go
@@ -79,9 +79,9 @@ type talosMachineConfigurationApplyResourceModelV1 struct { //nolint:govet
 }
 
 type onDestroyOptions struct {
-	Reset    bool `tfsdk:"reset"`
-	Graceful bool `tfsdk:"graceful"`
-	Reboot   bool `tfsdk:"reboot"`
+	Reset    types.Bool `tfsdk:"reset"`
+	Graceful types.Bool `tfsdk:"graceful"`
+	Reboot   types.Bool `tfsdk:"reboot"`
 }
 
 // NewTalosMachineConfigurationApplyResource implements the resource.Resource interface.
@@ -763,7 +763,7 @@ func (p *talosMachineConfigurationApplyResource) Delete(ctx context.Context, req
 		return
 	}
 
-	if state.OnDestroy != nil && state.OnDestroy.Reset {
+	if state.OnDestroy != nil && state.OnDestroy.Reset.ValueBool() {
 		// NOTE: During Delete, write-only attributes are not available (not in state)
 		// If using client_configuration_wo, the reset on destroy won't work
 		// Users must use client_configuration (non-write-only) if they need on_destroy.reset
@@ -812,8 +812,8 @@ func (p *talosMachineConfigurationApplyResource) Delete(ctx context.Context, req
 		}
 
 		resetRequest := &machineapi.ResetRequest{
-			Graceful: state.OnDestroy.Graceful,
-			Reboot:   state.OnDestroy.Reboot,
+			Graceful: state.OnDestroy.Graceful.ValueBool(),
+			Reboot:   state.OnDestroy.Reboot.ValueBool(),
 			SystemPartitionsToWipe: []*machineapi.ResetPartitionSpec{
 				{
 					Label: "STATE",
@@ -832,7 +832,7 @@ func (p *talosMachineConfigurationApplyResource) Delete(ctx context.Context, req
 
 		var postCheckFn func(context.Context, *client.Client, string) error
 
-		if state.OnDestroy.Reboot {
+		if state.OnDestroy.Reboot.ValueBool() {
 			postCheckFn = func(ctx context.Context, c *client.Client, preActionBootID string) error {
 				insecureClient, err := client.New(
 					ctx,

--- a/pkg/talos/talos_machine_configuration_apply_resource_test.go
+++ b/pkg/talos/talos_machine_configuration_apply_resource_test.go
@@ -586,3 +586,53 @@ resource "talos_machine_configuration_apply" "this" {
 }
 `
 }
+
+// TestAccTalosMachineConfigurationApplyOnDestroyUnknownBool is a regression test for
+// a model-type bug: on_destroy fields (graceful, reboot, reset) were declared as plain
+// bool in the resource model, which cannot hold unknown values. This surfaces when any
+// field is derived from an expression over an unknown value (e.g. a ternary on a
+// terraform_data output), producing:
+//
+//	Received unknown value, however the target type cannot handle unknown values.
+//	Path: on_destroy.graceful
+//	Target Type: bool
+//	Suggested Type: basetypes.BoolValue
+//
+// The test feeds terraform_data.flag.output (unknown at plan time) through a
+// conditional into on_destroy.graceful, reproducing the failure without a real node.
+func TestAccTalosMachineConfigurationApplyOnDestroyUnknownBool(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccTalosMachineConfigurationApplyOnDestroyUnknownBoolConfig(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccTalosMachineConfigurationApplyOnDestroyUnknownBoolConfig() string {
+	return `
+resource "terraform_data" "flag" {
+  input = "false"
+}
+
+resource "talos_machine_configuration_apply" "this" {
+  client_configuration = {
+    ca_certificate     = "fake-ca"
+    client_certificate = "fake-cert"
+    client_key         = "fake-key"
+  }
+  machine_configuration_input = "version: v1alpha1\nmachine:\n  type: controlplane\n"
+  node                        = "127.0.0.1"
+  endpoint                    = "127.0.0.1"
+  on_destroy = {
+    reset    = true
+    graceful = terraform_data.flag.output == "true" ? true : false
+    reboot   = false
+  }
+}
+`
+}

--- a/pkg/talos/talos_machine_resource.go
+++ b/pkg/talos/talos_machine_resource.go
@@ -592,7 +592,7 @@ func (r *talosMachineResource) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
-	if state.OnDestroy == nil || !state.OnDestroy.Reset {
+	if state.OnDestroy == nil || !state.OnDestroy.Reset.ValueBool() {
 		return
 	}
 
@@ -614,8 +614,8 @@ func (r *talosMachineResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	resetRequest := &machineapi.ResetRequest{
-		Graceful: state.OnDestroy.Graceful,
-		Reboot:   state.OnDestroy.Reboot,
+		Graceful: state.OnDestroy.Graceful.ValueBool(),
+		Reboot:   state.OnDestroy.Reboot.ValueBool(),
 		SystemPartitionsToWipe: []*machineapi.ResetPartitionSpec{
 			{Label: "STATE", Wipe: true},
 			{Label: "EPHEMERAL", Wipe: true},


### PR DESCRIPTION
…y block

Plain bool fields cannot hold unknown values produced by conditional expressions over unknown inputs (e.g. var ? true : false). Change onDestroyOptions fields to types.Bool and call ValueBool() at usage sites. Regressed with terraform-plugin-framework v1.19.0.

Fixes #334