### PR TITLE
fix(talos_machine): support drain_on_upgrade on worker nodes via kube…

### DIFF
--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -63,6 +63,24 @@ resource "talos_machine" "this" {
 }
 ```
 
+## Draining nodes before upgrade
+
+When `drain_on_upgrade = true` (the default) and `image` is set, a kubeconfig must be supplied via `kubeconfig_wo` (or `kubeconfig`) so the provider can cordon and drain the node before rebooting:
+
+```terraform
+ephemeral "talos_cluster_kubeconfig" "this" {
+  machine_secrets = talos_machine_secrets.this.machine_secrets
+  cluster_name    = "mycluster"
+  endpoint        = "https://<cp-ip>:6443"
+}
+
+resource "talos_machine" "worker" {
+  # ...
+  drain_on_upgrade = true
+  kubeconfig_wo    = ephemeral.talos_cluster_kubeconfig.this.kubeconfig_raw
+}
+```
+
 ## Upgrading multiple nodes safely
 
 When managing a multi-node cluster, upgrading all nodes in parallel risks losing etcd quorum. Use `depends_on` to chain upgrades sequentially, so each node is fully back before the next one starts:
@@ -116,6 +134,8 @@ The recommended workflow is two separate applies: upgrade `talos_cluster.kuberne
 - `drain_on_upgrade` (Boolean) Drain the node before rebooting during an upgrade, then uncordon after. Requires a healthy Kubernetes cluster. Use depends_on to sequence upgrades across nodes.
 - `endpoint` (String) The endpoint to use when connecting to the node. Defaults to node.
 - `image` (String) Talos installer image (e.g. `ghcr.io/siderolabs/installer:v1.9.0`). When set, upgrades if running version differs. When omitted, OS version is not managed.
+- `kubeconfig` (String, Sensitive) Kubeconfig used to drain and uncordon the node during upgrades. Required when drain_on_upgrade = true and image is set. Provide talos_cluster_kubeconfig.this.kubeconfig_raw. Use kubeconfig_wo when using ephemeral resources.
+- `kubeconfig_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only variant of kubeconfig. Requires Terraform 1.11+.
 - `machine_configuration` (String, Sensitive) The machine configuration YAML to apply. Use machine_configuration_wo when using ephemeral resources.
 - `machine_configuration_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only variant of machine_configuration for use with ephemeral resources. Requires Terraform 1.11+.
 - `on_destroy` (Attributes) Actions to be taken on destroy, if *reset* is not set this is a no-op.

--- a/pkg/talos/talos_cluster_kubeconfig_data_source.go
+++ b/pkg/talos/talos_cluster_kubeconfig_data_source.go
@@ -22,15 +22,15 @@ import (
 
 type talosClusterKubeConfigDataSource struct{}
 
-type talosClusterKubeConfigDataSourceModelV0 struct { //nolint:govet
+type talosClusterKubeConfigDataSourceModelV0 struct {
+	KubernetesClientConfiguration kubernetesClientConfiguration `tfsdk:"kubernetes_client_configuration"`
+	ClientConfiguration           clientConfiguration           `tfsdk:"client_configuration"`
 	ID                            types.String                  `tfsdk:"id"`
 	Node                          types.String                  `tfsdk:"node"`
 	Endpoint                      types.String                  `tfsdk:"endpoint"`
-	ClientConfiguration           clientConfiguration           `tfsdk:"client_configuration"`
 	KubeConfigRaw                 types.String                  `tfsdk:"kubeconfig_raw"`
-	KubernetesClientConfiguration kubernetesClientConfiguration `tfsdk:"kubernetes_client_configuration"`
-	Wait                          types.Bool                    `tfsdk:"wait"`
 	Timeouts                      timeouts.Value                `tfsdk:"timeouts"`
+	Wait                          types.Bool                    `tfsdk:"wait"`
 }
 
 var _ datasource.DataSource = &talosClusterKubeConfigDataSource{}

--- a/pkg/talos/talos_machine_disks_data_source.go
+++ b/pkg/talos/talos_machine_disks_data_source.go
@@ -33,14 +33,14 @@ type nodiskFoundError struct{}
 
 type talosMachineDisksDataSource struct{}
 
-type talosMachineDisksDataSourceModelV1 struct { //nolint:govet
+type talosMachineDisksDataSourceModelV1 struct {
+	ClientConfiguration clientConfiguration `tfsdk:"client_configuration"`
 	ID                  types.String        `tfsdk:"id"`
 	Node                types.String        `tfsdk:"node"`
 	Endpoint            types.String        `tfsdk:"endpoint"`
 	Selector            types.String        `tfsdk:"selector"`
-	ClientConfiguration clientConfiguration `tfsdk:"client_configuration"`
-	Disks               []diskspec          `tfsdk:"disks"`
 	Timeouts            timeouts.Value      `tfsdk:"timeouts"`
+	Disks               []diskspec          `tfsdk:"disks"`
 }
 
 var _ datasource.DataSource = &talosMachineDisksDataSource{}

--- a/pkg/talos/talos_machine_resource.go
+++ b/pkg/talos/talos_machine_resource.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/action"
-	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/kubeclient"
 	"github.com/siderolabs/talos/cmd/talosctl/pkg/talos/nodedrain"
 	commonapi "github.com/siderolabs/talos/pkg/machinery/api/common"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
@@ -40,6 +39,8 @@ import (
 	talosreporter "github.com/siderolabs/talos/pkg/reporter"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // DefaultCreateTimeout and DefaultUpdateTimeout are the out-of-the-box defaults
@@ -65,6 +66,8 @@ var (
 type talosMachineResourceModel struct {
 	OnDestroy                *onDestroyOptions     `tfsdk:"on_destroy"`
 	MachineConfigurationWO   types.String          `tfsdk:"machine_configuration_wo"`
+	Kubeconfig               types.String          `tfsdk:"kubeconfig"`
+	KubeconfigWO             types.String          `tfsdk:"kubeconfig_wo"`
 	Endpoint                 types.String          `tfsdk:"endpoint"`
 	ClientConfiguration      basetypes.ObjectValue `tfsdk:"client_configuration"`
 	ClientConfigurationWO    basetypes.ObjectValue `tfsdk:"client_configuration_wo"`
@@ -191,6 +194,20 @@ func (r *talosMachineResource) Schema(ctx context.Context, _ resource.SchemaRequ
 				Default:     booldefault.StaticBool(true),
 				Description: "Drain the node before rebooting during an upgrade, then uncordon after. Requires a healthy Kubernetes cluster. Use depends_on to sequence upgrades across nodes.",
 			},
+			"kubeconfig": schema.StringAttribute{
+				Optional:  true,
+				Sensitive: true,
+				Description: "Kubeconfig used to drain and uncordon the node during upgrades. " +
+					"Required when drain_on_upgrade = true and image is set. " +
+					"Provide talos_cluster_kubeconfig.this.kubeconfig_raw. " +
+					"Use kubeconfig_wo when using ephemeral resources.",
+			},
+			"kubeconfig_wo": schema.StringAttribute{
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Description: "Write-only variant of kubeconfig. Requires Terraform 1.11+.",
+			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
@@ -267,6 +284,39 @@ func (r *talosMachineResource) ValidateConfig(ctx context.Context, req resource.
 			"Only one of machine_configuration or machine_configuration_wo can be set, not both.",
 		)
 	}
+
+	if !cfg.Kubeconfig.IsNull() && !cfg.KubeconfigWO.IsNull() {
+		resp.Diagnostics.AddError(
+			"Conflicting kubeconfig",
+			"Only one of kubeconfig or kubeconfig_wo can be set, not both.",
+		)
+	}
+
+	// drain only runs during OS upgrades (when image is managed), so only require
+	// kubeconfig when image is also set. drain_on_upgrade defaults to true, so treat
+	// null the same as true. Skip unknown — can't evaluate references at validate time.
+	imageManaged := !cfg.Image.IsNull() && !cfg.Image.IsUnknown()
+	drainEnabled := cfg.DrainOnUpgrade.IsNull() || (!cfg.DrainOnUpgrade.IsUnknown() && cfg.DrainOnUpgrade.ValueBool())
+
+	if imageManaged && drainEnabled && kubeconfigMissing(&cfg) {
+		resp.Diagnostics.AddError(
+			"Missing kubeconfig for drain",
+			"drain_on_upgrade = true requires kubeconfig or kubeconfig_wo when image is set. "+
+				"Provide ephemeral.talos_cluster_kubeconfig.this.kubeconfig_raw via kubeconfig_wo.",
+		)
+	}
+}
+
+// kubeconfigMissing reports whether neither kubeconfig nor kubeconfig_wo carries a
+// usable value. Empty strings are treated the same as null — they would fail to parse
+// at runtime and produce a less clear error than the ValidateConfig message.
+func kubeconfigMissing(cfg *talosMachineResourceModel) bool {
+	// unknown = reference not yet resolved (e.g. ephemeral resource); skip validation.
+	absent := func(s types.String) bool {
+		return !s.IsUnknown() && (s.IsNull() || strings.TrimSpace(s.ValueString()) == "")
+	}
+
+	return absent(cfg.Kubeconfig) && absent(cfg.KubeconfigWO)
 }
 
 func (r *talosMachineResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
@@ -359,6 +409,10 @@ func (r *talosMachineResource) Create(ctx context.Context, req resource.CreateRe
 
 	if !cfgModel.MachineConfigurationWO.IsNull() {
 		plan.MachineConfigurationWO = cfgModel.MachineConfigurationWO
+	}
+
+	if !cfgModel.KubeconfigWO.IsNull() {
+		plan.KubeconfigWO = cfgModel.KubeconfigWO
 	}
 
 	talosConfig, resolvedClientConfig, err := resolveTalosMachineClientConfig(ctx, &plan)
@@ -524,6 +578,10 @@ func (r *talosMachineResource) Update(ctx context.Context, req resource.UpdateRe
 
 	if !cfgModel.MachineConfigurationWO.IsNull() {
 		plan.MachineConfigurationWO = cfgModel.MachineConfigurationWO
+	}
+
+	if !cfgModel.KubeconfigWO.IsNull() {
+		plan.KubeconfigWO = cfgModel.KubeconfigWO
 	}
 
 	talosConfig, resolvedClientConfig, err := resolveTalosMachineClientConfig(ctx, &plan)
@@ -715,7 +773,12 @@ func talosMachineUpgradeIfNeeded(ctx context.Context, endpoint, node string, tal
 		return fmt.Errorf("installing new OS image: %w", installErr)
 	}
 
-	k8sNodeName, err := talosMachineCordonAndDrain(ctx, endpoint, node, talosConfig, state.DrainOnUpgrade.ValueBool())
+	rawKubeconfig := state.KubeconfigWO.ValueString()
+	if rawKubeconfig == "" {
+		rawKubeconfig = state.Kubeconfig.ValueString()
+	}
+
+	k8sNodeName, err := talosMachineCordonAndDrain(ctx, endpoint, node, talosConfig, state.DrainOnUpgrade.ValueBool(), rawKubeconfig)
 	if err != nil {
 		return fmt.Errorf("draining node: %w", err)
 	}
@@ -726,7 +789,7 @@ func talosMachineUpgradeIfNeeded(ctx context.Context, endpoint, node string, tal
 			return
 		}
 
-		if err := talosMachineUncordon(ctx, endpoint, node, talosConfig, k8sNodeName); err != nil {
+		if err := talosMachineUncordon(ctx, endpoint, node, talosConfig, k8sNodeName, rawKubeconfig); err != nil {
 			retErr = errors.Join(retErr, fmt.Errorf("uncordoning node: %w", err))
 		}
 	}()
@@ -825,7 +888,7 @@ func talosMachineInstallImage(ctx context.Context, endpoint, node string, talosC
 	})
 }
 
-func talosMachineCordonAndDrain(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, drain bool) (string, error) {
+func talosMachineCordonAndDrain(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, drain bool, rawKubeconfig string) (string, error) {
 	if !drain {
 		return "", nil
 	}
@@ -834,12 +897,12 @@ func talosMachineCordonAndDrain(ctx context.Context, endpoint, node string, talo
 
 	noopReport := func(talosreporter.Update) {}
 
-	if err := talosClientOp(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
-		cs, err := kubeclient.FromTalosClient(nodeCtx, c)
-		if err != nil {
-			return fmt.Errorf("building k8s client for drain: %w", err)
-		}
+	cs, err := kubeclientFromRaw([]byte(rawKubeconfig))
+	if err != nil {
+		return "", fmt.Errorf("building k8s client for drain: %w", err)
+	}
 
+	if err := talosClientOp(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
 		k8sName, err := nodedrain.GetKubernetesNodeName(nodeCtx, c)
 		if err != nil {
 			return fmt.Errorf("resolving k8s node name: %w", err)
@@ -855,21 +918,40 @@ func talosMachineCordonAndDrain(ctx context.Context, endpoint, node string, talo
 	return k8sNodeName, nil
 }
 
-func talosMachineUncordon(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, k8sNodeName string) error {
+func talosMachineUncordon(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, k8sNodeName, rawKubeconfig string) error {
+	cs, err := kubeclientFromRaw([]byte(rawKubeconfig))
+	if err != nil {
+		return fmt.Errorf("building k8s client for uncordon: %w", err)
+	}
+
 	noopReport := func(talosreporter.Update) {}
 
 	return talosClientOp(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
-		cs, err := kubeclient.FromTalosClient(nodeCtx, c)
-		if err != nil {
-			return fmt.Errorf("building k8s client for uncordon: %w", err)
-		}
-
 		if waitErr := nodedrain.WaitForNodeReady(ctx, cs, k8sNodeName, 5*time.Minute); waitErr != nil {
 			return fmt.Errorf("waiting for node ready: %w", waitErr)
 		}
 
 		return nodedrain.Uncordon(ctx, cs, k8sNodeName, noopReport)
 	})
+}
+
+func kubeclientFromRaw(kubeconfigBytes []byte) (kubernetes.Interface, error) {
+	config, err := clientcmd.NewClientConfigFromBytes(kubeconfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing kubeconfig: %w", err)
+	}
+
+	restConfig, err := config.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("building REST config: %w", err)
+	}
+
+	cs, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating k8s clientset: %w", err)
+	}
+
+	return cs, nil
 }
 
 func talosMachineReboot(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, rebootModeStr string) error {

--- a/pkg/talos/talos_machine_resource_test.go
+++ b/pkg/talos/talos_machine_resource_test.go
@@ -63,6 +63,276 @@ func TestAccTalosMachine_bootstrap(t *testing.T) {
 	})
 }
 
+// TestAccTalosMachine_drainWorkerUpgrade verifies that drain_on_upgrade = true works
+// on worker nodes when kubeconfig_wo is provided. Workers do not serve the Talos
+// kubeconfig API, so the provider must use the supplied kubeconfig to cordon and drain.
+// Uses Talos v1.13.x so the LifecycleService path (pull → install → drain → reboot →
+// uncordon) is exercised; the legacy path (< v1.13) silently skips drain.
+func TestAccTalosMachine_drainWorkerUpgrade(t *testing.T) {
+	const (
+		baseVersion    = "v1.13.0-rc.0"
+		upgradeVersion = "v1.13.0"
+	)
+
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"libvirt": {
+				Source:            "dmacvicar/libvirt",
+				VersionConstraint: "= 0.8.3",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: CP + worker, cluster bootstrapped and healthy.
+			{
+				Config: testAccTalosMachineWorkerDrainConfig(rName, baseVersion, baseVersion),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("talos_machine.cp", "machine_configuration_hash"),
+					resource.TestCheckResourceAttrSet("talos_machine.worker", "machine_configuration_hash"),
+					resource.TestCheckResourceAttrSet("data.talos_cluster_health.this", "id"),
+				),
+			},
+			// Step 2: upgrade the worker with drain_on_upgrade = true.
+			// The worker must be drained via the Kubernetes API before rebooting.
+			{
+				Config: testAccTalosMachineWorkerDrainConfig(rName, baseVersion, upgradeVersion),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("talos_machine.worker", "image",
+						fmt.Sprintf("ghcr.io/siderolabs/installer:%s", upgradeVersion)),
+					resource.TestCheckResourceAttrSet("data.talos_cluster_health.this", "id"),
+				),
+			},
+		},
+	})
+}
+
+// testAccTalosMachineWorkerDrainConfig creates a CP + worker cluster where the
+// worker has drain_on_upgrade = true. cpImageTag is the Talos version for the CP;
+// workerImageTag is the target image for the worker (bumped in step 2 to trigger upgrade).
+func testAccTalosMachineWorkerDrainConfig(rName, cpImageTag, workerImageTag string) string {
+	cpuMode := cpuModeDefault
+	if os.Getenv("CI") != "" {
+		cpuMode = cpuModeCI
+	}
+
+	// Both CP and worker boot from the same base ISO. The worker upgrade target
+	// is controlled via talos_machine.image, not the ISO URL.
+	isoURL := fmt.Sprintf(
+		"https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso",
+		cpImageTag,
+	)
+
+	return fmt.Sprintf(`
+resource "talos_machine_secrets" "this" {}
+
+data "talos_machine_configuration" "cp" {
+  cluster_name       = "test"
+  cluster_endpoint   = "https://${libvirt_domain.cp.network_interface[0].addresses[0]}:6443"
+  machine_type       = "controlplane"
+  machine_secrets    = talos_machine_secrets.this.machine_secrets
+  talos_version      = %[4]q
+  kubernetes_version = "v1.35.3"
+  docs               = false
+  examples           = false
+  config_patches = [
+    yamlencode({
+      machine = {
+        install = {
+          disk  = "/dev/vda"
+          image = "ghcr.io/siderolabs/installer:%[4]s"
+        }
+      }
+    })
+  ]
+}
+
+data "talos_machine_configuration" "worker" {
+  cluster_name       = "test"
+  cluster_endpoint   = "https://${libvirt_domain.cp.network_interface[0].addresses[0]}:6443"
+  machine_type       = "worker"
+  machine_secrets    = talos_machine_secrets.this.machine_secrets
+  talos_version      = %[4]q
+  kubernetes_version = "v1.35.3"
+  docs               = false
+  examples           = false
+  config_patches = [
+    yamlencode({
+      machine = {
+        install = {
+          disk  = "/dev/vda"
+          image = "ghcr.io/siderolabs/installer:%[4]s"
+        }
+      }
+    })
+  ]
+}
+
+resource "libvirt_volume" "cp" {
+  name = "%[1]s-cp"
+  size = 6442450944
+}
+
+resource "libvirt_domain" "cp" {
+  name     = "%[1]s-cp"
+  firmware = "/usr/share/OVMF/OVMF_CODE_4M.fd"
+
+  nvram {
+    file     = "/var/lib/libvirt/qemu/nvram/%[1]s-cp_VARS.fd"
+    template = "/usr/share/OVMF/OVMF_VARS_4M.fd"
+  }
+
+  lifecycle {
+    ignore_changes = [cpu, nvram, disk["url"]]
+  }
+
+  cpu {
+    mode = %[2]q
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
+
+  disk {
+    url = %[3]q
+  }
+
+  disk {
+    volume_id = libvirt_volume.cp.id
+  }
+
+  boot_device {
+    dev = ["cdrom"]
+  }
+
+  network_interface {
+    network_name   = "default"
+    wait_for_lease = true
+  }
+
+  vcpu   = "2"
+  memory = "4096"
+}
+
+resource "libvirt_volume" "worker" {
+  name = "%[1]s-worker"
+  size = 6442450944
+}
+
+resource "libvirt_domain" "worker" {
+  name     = "%[1]s-worker"
+  firmware = "/usr/share/OVMF/OVMF_CODE_4M.fd"
+
+  nvram {
+    file     = "/var/lib/libvirt/qemu/nvram/%[1]s-worker_VARS.fd"
+    template = "/usr/share/OVMF/OVMF_VARS_4M.fd"
+  }
+
+  lifecycle {
+    ignore_changes = [cpu, nvram, disk["url"]]
+  }
+
+  cpu { mode = %[2]q }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
+
+  disk {
+    url = %[3]q
+  }
+
+  disk {
+    volume_id = libvirt_volume.worker.id
+  }
+
+  boot_device {
+    dev = ["cdrom"]
+  }
+
+  network_interface {
+    network_name   = "default"
+    wait_for_lease = true
+  }
+
+  vcpu   = "2"
+  memory = "4096"
+}
+
+resource "talos_machine" "cp" {
+  node                  = libvirt_domain.cp.network_interface[0].addresses[0]
+  endpoint              = libvirt_domain.cp.network_interface[0].addresses[0]
+  client_configuration  = talos_machine_secrets.this.client_configuration
+  machine_configuration = data.talos_machine_configuration.cp.machine_configuration
+  image                 = "ghcr.io/siderolabs/installer:%[4]s"
+  drain_on_upgrade      = false
+
+  timeouts = {
+    create = "20m"
+    update = "60m"
+    delete = "5m"
+  }
+}
+
+resource "talos_machine_bootstrap" "this" {
+  depends_on           = [talos_machine.cp]
+  node                 = libvirt_domain.cp.network_interface[0].addresses[0]
+  client_configuration = talos_machine_secrets.this.client_configuration
+}
+
+ephemeral "talos_cluster_kubeconfig" "this" {
+  machine_secrets = talos_machine_secrets.this.machine_secrets
+  cluster_name    = "test"
+  endpoint        = "https://${libvirt_domain.cp.network_interface[0].addresses[0]}:6443"
+}
+
+resource "talos_machine" "worker" {
+  depends_on            = [talos_machine_bootstrap.this]
+  node                  = libvirt_domain.worker.network_interface[0].addresses[0]
+  endpoint              = libvirt_domain.worker.network_interface[0].addresses[0]
+  client_configuration  = talos_machine_secrets.this.client_configuration
+  machine_configuration = data.talos_machine_configuration.worker.machine_configuration
+  image                 = "ghcr.io/siderolabs/installer:%[5]s"
+  drain_on_upgrade      = true
+  kubeconfig_wo         = ephemeral.talos_cluster_kubeconfig.this.kubeconfig_raw
+
+  timeouts = {
+    create = "20m"
+    update = "60m"
+    delete = "5m"
+  }
+}
+
+data "talos_cluster_health" "this" {
+  depends_on = [talos_machine.worker]
+
+  client_configuration = talos_machine_secrets.this.client_configuration
+  endpoints            = libvirt_domain.cp.network_interface[0].addresses
+  control_plane_nodes  = libvirt_domain.cp.network_interface[0].addresses
+  worker_nodes         = libvirt_domain.worker.network_interface[0].addresses
+
+  timeouts = { read = "25m" }
+}
+`, rName, cpuMode, isoURL, cpImageTag, workerImageTag)
+}
+
 // TestAccTalosMachine_upgrade tests that changing `image` triggers an OS upgrade:
 // the node is initially at v1.12.7 and is upgraded to v1.13.0.
 func TestAccTalosMachine_upgrade(t *testing.T) {
@@ -443,6 +713,183 @@ resource "talos_machine" "this" {
   }
 }
 `, rName, cpuMode, isoURL, imageTag, isoVersion)
+}
+
+// TestValidateConfig_DrainKubeconfigRequirement verifies that ValidateConfig rejects
+// configs where drain_on_upgrade is enabled (explicitly or by default), image is managed,
+// and no kubeconfig is supplied. Drain only runs during OS upgrades (when image is set),
+// so configs without image must not require kubeconfig.
+//
+// Regression: drain_on_upgrade defaults to true, so omitting it (null in config, before
+// defaults are applied) must also trigger the error — not silently pass.
+func TestValidateConfig_DrainKubeconfigRequirement(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := talos.NewTalosMachineResource()
+
+	var schemaResp frameworkresource.SchemaResponse
+
+	r.Schema(ctx, frameworkresource.SchemaRequest{}, &schemaResp)
+
+	sch := schemaResp.Schema
+
+	schTFType, ok := sch.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema TerraformType is not tftypes.Object")
+	}
+
+	clientConfigAttrType, ok := schTFType.AttributeTypes["client_configuration"].(tftypes.Object)
+	if !ok {
+		t.Fatal("client_configuration attribute type is not tftypes.Object")
+	}
+
+	clientConfigVal := tftypes.NewValue(clientConfigAttrType, map[string]tftypes.Value{
+		"ca_certificate":     tftypes.NewValue(tftypes.String, "ca"),
+		"client_certificate": tftypes.NewValue(tftypes.String, "cert"),
+		"client_key":         tftypes.NewValue(tftypes.String, "key"),
+	})
+
+	nullVals := func() map[string]tftypes.Value {
+		m := make(map[string]tftypes.Value, len(schTFType.AttributeTypes))
+		for name, typ := range schTFType.AttributeTypes {
+			m[name] = tftypes.NewValue(typ, nil)
+		}
+
+		return m
+	}
+
+	boolVal := func(b bool) tftypes.Value { return tftypes.NewValue(tftypes.Bool, b) }
+	boolValPtr := func(b bool) *tftypes.Value {
+		v := boolVal(b)
+
+		return &v
+	}
+
+	strPtr := func(s string) *string { return &s }
+
+	const imageRef = "ghcr.io/siderolabs/installer:v1.13.0"
+
+	tests := []struct {
+		drainOnUpgrade      *tftypes.Value // nil = omitted (null) in config
+		kubeconfig          *string        // nil = null; &"" = empty string; &"x" = value
+		kubeconfigWO        *string        // nil = null; &"" = empty string; &"x" = value
+		name                string
+		imageSet            bool // true = set image to imageRef
+		kubeconfigWOUnknown bool // true = kubeconfig_wo is an unresolved reference (unknown)
+		wantError           bool
+	}{
+		{
+			name:           "image set, drain=true explicit, no kubeconfig",
+			imageSet:       true,
+			drainOnUpgrade: boolValPtr(true),
+			wantError:      true,
+		},
+		{
+			name:           "image set, drain omitted (defaults to true), no kubeconfig",
+			imageSet:       true,
+			drainOnUpgrade: nil,
+			wantError:      true,
+		},
+		{
+			name:           "image set, drain=true, kubeconfig empty string",
+			imageSet:       true,
+			drainOnUpgrade: boolValPtr(true),
+			kubeconfig:     strPtr(""),
+			wantError:      true,
+		},
+		{
+			name:           "image set, drain=true, kubeconfig whitespace",
+			imageSet:       true,
+			drainOnUpgrade: boolValPtr(true),
+			kubeconfig:     strPtr("   "),
+			wantError:      true,
+		},
+		{
+			name:           "image set, drain=false, no kubeconfig",
+			imageSet:       true,
+			drainOnUpgrade: boolValPtr(false),
+			wantError:      false,
+		},
+		{
+			name:           "image set, drain=true, kubeconfig set",
+			imageSet:       true,
+			drainOnUpgrade: boolValPtr(true),
+			kubeconfig:     strPtr("kubeconfig-yaml-content"),
+			wantError:      false,
+		},
+		{
+			name:           "image set, drain=true, kubeconfig_wo set",
+			imageSet:       true,
+			drainOnUpgrade: boolValPtr(true),
+			kubeconfigWO:   strPtr("kubeconfig-yaml-content"),
+			wantError:      false,
+		},
+		{
+			name:           "no image (config-only), drain=true, no kubeconfig",
+			imageSet:       false,
+			drainOnUpgrade: boolValPtr(true),
+			wantError:      false,
+		},
+		{
+			name:                "image set, drain=true, kubeconfig_wo unknown (ephemeral ref not yet resolved)",
+			imageSet:            true,
+			drainOnUpgrade:      boolValPtr(true),
+			kubeconfigWOUnknown: true,
+			wantError:           false,
+		},
+	}
+
+	rvc, ok := r.(frameworkresource.ResourceWithValidateConfig)
+	if !ok {
+		t.Fatal("resource does not implement ResourceWithValidateConfig")
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			vals := nullVals()
+			vals["client_configuration"] = clientConfigVal
+			vals["machine_configuration"] = tftypes.NewValue(tftypes.String, "config: {}")
+
+			if tc.imageSet {
+				vals["image"] = tftypes.NewValue(tftypes.String, imageRef)
+			}
+
+			if tc.drainOnUpgrade == nil {
+				vals["drain_on_upgrade"] = tftypes.NewValue(tftypes.Bool, nil)
+			} else {
+				vals["drain_on_upgrade"] = *tc.drainOnUpgrade
+			}
+
+			if tc.kubeconfig != nil {
+				vals["kubeconfig"] = tftypes.NewValue(tftypes.String, *tc.kubeconfig)
+			}
+
+			if tc.kubeconfigWOUnknown {
+				vals["kubeconfig_wo"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+			} else if tc.kubeconfigWO != nil {
+				vals["kubeconfig_wo"] = tftypes.NewValue(tftypes.String, *tc.kubeconfigWO)
+			}
+
+			raw := tftypes.NewValue(tftypes.Object{AttributeTypes: schTFType.AttributeTypes}, vals)
+			req := frameworkresource.ValidateConfigRequest{
+				Config: tfsdk.Config{Schema: sch, Raw: raw},
+			}
+			resp := frameworkresource.ValidateConfigResponse{}
+
+			rvc.ValidateConfig(ctx, req, &resp)
+
+			if tc.wantError && !resp.Diagnostics.HasError() {
+				t.Error("expected validation error, got none")
+			}
+
+			if !tc.wantError && resp.Diagnostics.HasError() {
+				t.Errorf("unexpected validation error: %v", resp.Diagnostics)
+			}
+		})
+	}
 }
 
 // TestImageHasUseStateForUnknown verifies that `image` carries UseStateForUnknown.

--- a/pkg/talos/util.go
+++ b/pkg/talos/util.go
@@ -40,16 +40,16 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
-type machineConfigGenerateOptions struct { //nolint:govet
-	machineType       machine.Type
+type machineConfigGenerateOptions struct {
+	machineSecrets    *secrets.Bundle
 	clusterName       string
 	clusterEndpoint   string
-	machineSecrets    *secrets.Bundle
 	kubernetesVersion string
 	talosVersion      string
+	configPatches     []string
+	machineType       machine.Type
 	docsEnabled       bool
 	examplesEnabled   bool
-	configPatches     []string
 }
 
 func (m *machineConfigGenerateOptions) generate() (string, error) {

--- a/templates/resources/machine.md.tmpl
+++ b/templates/resources/machine.md.tmpl
@@ -33,6 +33,24 @@ resource "talos_machine" "this" {
 }
 ```
 
+## Draining nodes before upgrade
+
+When `drain_on_upgrade = true` (the default) and `image` is set, a kubeconfig must be supplied via `kubeconfig_wo` (or `kubeconfig`) so the provider can cordon and drain the node before rebooting:
+
+```terraform
+ephemeral "talos_cluster_kubeconfig" "this" {
+  machine_secrets = talos_machine_secrets.this.machine_secrets
+  cluster_name    = "mycluster"
+  endpoint        = "https://<cp-ip>:6443"
+}
+
+resource "talos_machine" "worker" {
+  # ...
+  drain_on_upgrade = true
+  kubeconfig_wo    = ephemeral.talos_cluster_kubeconfig.this.kubeconfig_raw
+}
+```
+
 ## Upgrading multiple nodes safely
 
 When managing a multi-node cluster, upgrading all nodes in parallel risks losing etcd quorum. Use `depends_on` to chain upgrades sequentially, so each node is fully back before the next one starts:


### PR DESCRIPTION
…config(_wo)

Workers do not serve the Talos kubeconfig API, so kubeclient.FromTalosClient fails with 'kubeconfig is only available on control plane nodes'. Add kubeconfig and kubeconfig_wo attributes; kubeconfig(_wo) is now always required when drain_on_upgrade = true (validated at config time). Fixes GitHub issue #347.