### PR TITLE
fix(test): bump latest talos stable version to v1.13.3

### DIFF
--- a/pkg/talos/talos_image_factory_versions_data_source_test.go
+++ b/pkg/talos/talos_image_factory_versions_data_source_test.go
@@ -26,7 +26,7 @@ func TestAccTalosImageFactoryVersionsDataSource(t *testing.T) {
 			{
 				Config: testAccTalosImageFactoryVersionsDataSourceWithFilterConfig(),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownOutputValue("talos_version", knownvalue.StringExact("v1.13.2")),
+					statecheck.ExpectKnownOutputValue("talos_version", knownvalue.StringExact("v1.13.3")),
 				},
 			},
 		},


### PR DESCRIPTION
v1.13.3 was released after the last deps bump, causing the
TestAccTalosImageFactoryVersionsDataSource acceptance test to fail.
The test pins the latest known stable version to verify the
stable_versions_only filter returns the expected latest release.