### PR TITLE
fix(deps): upgrade Go to 1.26.4 to fix crypto/x509 vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/siderolabs/terraform-provider-talos
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
## Summary

- Bumps `go` directive in `go.mod` from 1.26.3 to 1.26.4
- Fixes `go-vulncheck` CI failures caused by known `crypto/x509` vulnerabilities in Go 1.26.3 (fixed in 1.26.4)

## Test plan

- [ ] `check-dirty` / `go-vulncheck` passes in CI