### PR TITLE
perf(talos_machine): decouple talosMachineUncordon from Talos API

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/pkg/talos/talos_image_factory_versions_data_source_test.go
+++ b/pkg/talos/talos_image_factory_versions_data_source_test.go
@@ -26,7 +26,7 @@ func TestAccTalosImageFactoryVersionsDataSource(t *testing.T) {
 			{
 				Config: testAccTalosImageFactoryVersionsDataSourceWithFilterConfig(),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownOutputValue("talos_version", knownvalue.StringExact("v1.13.3")),
+					statecheck.ExpectKnownOutputValue("talos_version", knownvalue.StringExact("v1.13.4")),
 				},
 			},
 		},

--- a/pkg/talos/talos_machine_resource.go
+++ b/pkg/talos/talos_machine_resource.go
@@ -782,7 +782,7 @@ func talosMachineUpgrade(ctx context.Context, endpoint, node string, talosConfig
 			return
 		}
 
-		if err := talosMachineUncordon(ctx, endpoint, node, talosConfig, k8sNodeName, rawKubeconfig); err != nil {
+		if err := talosMachineUncordon(ctx, k8sNodeName, rawKubeconfig); err != nil {
 			retErr = errors.Join(retErr, fmt.Errorf("uncordoning node: %w", err))
 		}
 	}()
@@ -926,7 +926,7 @@ func talosMachineCordonAndDrain(ctx context.Context, endpoint, node string, talo
 	return k8sNodeName, nil
 }
 
-func talosMachineUncordon(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, k8sNodeName, rawKubeconfig string) error {
+func talosMachineUncordon(ctx context.Context, k8sNodeName, rawKubeconfig string) error {
 	cs, err := kubeclientFromRaw([]byte(rawKubeconfig))
 	if err != nil {
 		return fmt.Errorf("building k8s client for uncordon: %w", err)
@@ -934,13 +934,11 @@ func talosMachineUncordon(ctx context.Context, endpoint, node string, talosConfi
 
 	noopReport := func(talosreporter.Update) {}
 
-	return talosClientOp(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
-		if waitErr := nodedrain.WaitForNodeReady(ctx, cs, k8sNodeName, 5*time.Minute); waitErr != nil {
-			return fmt.Errorf("waiting for node ready: %w", waitErr)
-		}
+	if waitErr := nodedrain.WaitForNodeReady(ctx, cs, k8sNodeName, 5*time.Minute); waitErr != nil {
+		return fmt.Errorf("waiting for node ready: %w", waitErr)
+	}
 
-		return nodedrain.Uncordon(ctx, cs, k8sNodeName, noopReport)
-	})
+	return nodedrain.Uncordon(ctx, cs, k8sNodeName, noopReport)
 }
 
 func kubeclientFromRaw(kubeconfigBytes []byte) (kubernetes.Interface, error) {


### PR DESCRIPTION
Uncordon and WaitForNodeReady are pure Kubernetes operations and do not need a Talos gRPC connection. Wrapping them in talosClientOp caused silent uncordon failures whenever the Talos API was unreachable after a reboot, leaving the node permanently cordoned.