### PR TITLE
fix(talos_machine): recover from half-open connection after reboot

### DIFF
--- a/pkg/talos/talos_machine_resource.go
+++ b/pkg/talos/talos_machine_resource.go
@@ -7,6 +7,7 @@ package talos
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -37,6 +38,7 @@ import (
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	configresource "github.com/siderolabs/talos/pkg/machinery/resources/config"
 	talosreporter "github.com/siderolabs/talos/pkg/reporter"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/client-go/kubernetes"
@@ -960,6 +962,56 @@ func kubeclientFromRaw(kubeconfigBytes []byte) (kubernetes.Interface, error) {
 	return cs, nil
 }
 
+// rebootExecutor implements action.ClientExecutor for the reboot-tracking path.
+// Unlike clientExecutor (which reuses a pre-built *client.Client and discards dial
+// options), this builds a fresh client on each WithClient call and applies the
+// dial options passed by the tracker — notably disabled gRPC backoff and keepalive
+// (10s/5s). This mirrors talosctl's GlobalArgs.WithClientNoNodes behavior and ensures
+// the gRPC ClientConn recovers quickly after the node reboots rather than waiting
+// through the default 120s exponential backoff before reconnecting.
+type rebootExecutor struct {
+	talosConfig *clientconfig.Config
+	setupCtx    context.Context //nolint:containedctx
+	endpoint    string
+	node        string
+}
+
+func (r *rebootExecutor) WithClient(fn func(context.Context, *client.Client) error, dialOpts ...grpc.DialOption) error {
+	c, err := client.New(r.setupCtx,
+		client.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}), //nolint:gosec
+		client.WithEndpoints(r.endpoint),
+		client.WithGRPCDialOptions(dialOpts...),
+	)
+	if err != nil {
+		return err
+	}
+
+	nodeCtx := client.WithNode(r.setupCtx, r.node)
+
+	if _, testErr := c.Disks(nodeCtx); testErr != nil {
+		c.Close() //nolint:errcheck
+
+		c, err = client.New(r.setupCtx,
+			client.WithConfig(r.talosConfig),
+			client.WithEndpoints(r.endpoint),
+			client.WithGRPCDialOptions(dialOpts...),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	defer c.Close() //nolint:errcheck
+
+	ctx := client.WithNode(context.Background(), r.node)
+
+	return fn(ctx, c)
+}
+
+func (r *rebootExecutor) NodeList() []string {
+	return []string{r.node}
+}
+
 func talosMachineReboot(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, rebootModeStr string) error {
 	rebootModeVal, ok := machineapi.RebootRequest_Mode_value[rebootModeStr]
 	if !ok {
@@ -967,29 +1019,26 @@ func talosMachineReboot(ctx context.Context, endpoint, node string, talosConfig 
 	}
 
 	rebootMode := machineapi.RebootRequest_Mode(rebootModeVal)
+	executor := &rebootExecutor{talosConfig: talosConfig, setupCtx: ctx, endpoint: endpoint, node: node}
 
-	return talosClientOp(ctx, endpoint, node, talosConfig, func(_ context.Context, c *client.Client) error {
-		executor := newClientExecutor(c, []string{node})
+	return action.NewTracker(
+		executor,
+		action.MachineReadyEventFn,
+		func(rebootCtx context.Context, c *client.Client) (string, error) {
+			resp, err := c.RebootWithResponse(rebootCtx, client.WithRebootMode(rebootMode))
+			if err != nil {
+				return "", err
+			}
 
-		return action.NewTracker(
-			executor,
-			action.MachineReadyEventFn,
-			func(rebootCtx context.Context, c *client.Client) (string, error) {
-				resp, err := c.RebootWithResponse(rebootCtx, client.WithRebootMode(rebootMode))
-				if err != nil {
-					return "", err
-				}
+			if len(resp.GetMessages()) == 0 {
+				return "", errors.New("no messages returned from reboot")
+			}
 
-				if len(resp.GetMessages()) == 0 {
-					return "", errors.New("no messages returned from reboot")
-				}
-
-				return resp.GetMessages()[0].GetActorId(), nil
-			},
-			action.WithPostCheck(action.BootIDChangedPostCheckFn),
-			action.WithTimeout(15*time.Minute),
-		).Run()
-	})
+			return resp.GetMessages()[0].GetActorId(), nil
+		},
+		action.WithPostCheck(action.BootIDChangedPostCheckFn),
+		action.WithTimeout(15*time.Minute),
+	).Run()
 }
 
 // talosMachineUpgradeLegacy handles Talos < 1.13 nodes where LifecycleService is not available.


### PR DESCRIPTION
## What was happening

OS upgrades via `talos_machine` hung ~15 min after the node rebooted, then timed out — even though the node was already back up and `Ready` within seconds.

## Root cause

`talosMachineReboot` tracks the reboot with `action.Tracker`, watching a **receive-only** event stream for the node to return. The tracker passes gRPC keepalive (`10s/5s`) to `ClientExecutor.WithClient`, but the `clientExecutor` it used declared `_ ...grpc.DialOption` and silently dropped it.

`DEFAULT` reboot uses **kexec**: the node jumps to the new kernel and the old TCP connection is left **half-open** (no `RST`/`FIN`). With keepalive dropped and nothing to send on the stream, gRPC never probed the dead connection — the watch blocked forever, no error fired, and it hung until the 15-min deadline.

**Why keepalive, not backoff:** gRPC backoff caps at `120s`, so a clean close would have recovered in ~2 min even with the option dropped. Hitting the full timeout means the connection died silently — only keepalive detects that.

## The fix

`rebootExecutor` builds the client like the existing `talosClientOp` (insecure probe then mTLS, direct endpoint) and additionally applies the tracker's keepalive/backoff dial options via `client.WithGRPCDialOptions` (the same params talosctl's tracker passes). Reconnect drops from ~15 min to ~15s.

## Notes

- The two reset-on-destroy tracker paths share the same `clientExecutor` but wait for a *pre-reboot* event, so they aren't affected; unifying them is left for a follow-up.
- Filed as a **fix**, not perf — the prior behavior was a hang, not a slow-but-correct path.

## Test plan

- [x] `go test ./pkg/talos/...`
- [ ] CI acceptance tests
- [ ] Live worker upgrade reconnects in seconds post-reboot

## Related

Follows #364 (decouple uncordon) and #365 (decouple drain).