### PR TITLE
feat(talos_machine): add import support for existing nodes

### DIFF
--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -205,3 +205,65 @@ Optional:
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+
+## Import
+
+Talos machines can be imported using the node IP address or hostname, e.g.
+
+```shell
+terraform import talos_machine.example 10.5.0.2
+```
+
+### Prerequisites
+
+Import only records identity (`id`, `node`, `endpoint`). It does not read
+certificates from the node.
+
+**Provider version:** `talos_machine` exists from provider **v0.12.0-alpha.0**
+onward. Import support for this resource requires a provider build that includes
+`ImportState` for `talos_machine` (this feature). The cluster itself does not
+need to have been created by that same provider version. A common path is to
+create the cluster with **v0.11.x** (`talos_machine_configuration_apply` +
+bootstrap + secrets), then adopt the node with a **v0.12+** provider that
+supports `talos_machine` import.
+
+**Credentials in state:** Wire `client_configuration` from an existing secrets
+resource (typical when migrating off `talos_machine_configuration_apply`):
+
+```terraform
+resource "talos_machine" "example" {
+  node                 = "10.5.0.2"
+  client_configuration = talos_machine_secrets.this.client_configuration
+  # ...
+}
+```
+
+`talos_machine_secrets` should already be in state (or import it first with
+`terraform import talos_machine_secrets.this <path-to-secrets.yaml>`).
+
+**Import ID must match `node`:** `node` has `RequiresReplace`. The import ID
+becomes both `id` and `node` in state. If HCL `node` does not match that value
+exactly (for example import by IP but configure a hostname, or the reverse), the
+first plan is a **destroy/create** of the live machine instead of an in-place
+state fill. Use the same address string in the import ID and in `node`.
+
+### What to expect after import
+
+1. `terraform state show` lists `id` / `node` / `endpoint` only at first.
+2. `terraform plan` shows an **in-place update** that fills attributes from HCL
+   (`client_configuration`, `image`, `machine_configuration`, flags such as
+   `drain_on_upgrade`, and so on). That is expected when import ID matches `node`.
+   It does **not** mean Terraform will recreate the VM or that those values are
+   missing from the cluster.
+3. `terraform apply` of that plan copies HCL into this resource's state. On that
+   post-import apply (state `image` is null), the provider observes the live
+   machine first: it skips OS upgrade when the running version already matches
+   `image`, and skips machine-config apply when the live config hash already
+   matches. Later applies that change `image` always upgrade (including same tag
+   with a new schematic). If HCL differs from the node, apply upgrades or
+   re-applies as usual.
+4. A following `terraform plan` should report no changes when configuration matches
+   the node.
+
+

--- a/examples/resources/talos_machine/import.sh
+++ b/examples/resources/talos_machine/import.sh
@@ -1,0 +1,5 @@
+# Import records identity (id/node/endpoint). The import ID must match HCL
+# `node` exactly (RequiresReplace). Expect a follow-up plan/apply that fills
+# client_configuration and other attributes from HCL (typically from
+# talos_machine_secrets already in state). See the resource docs Import section.
+terraform import talos_machine.example 10.5.0.2

--- a/pkg/talos/talos_machine_resource.go
+++ b/pkg/talos/talos_machine_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -61,6 +62,7 @@ var (
 	_ resource.Resource                   = &talosMachineResource{}
 	_ resource.ResourceWithModifyPlan     = &talosMachineResource{}
 	_ resource.ResourceWithValidateConfig = &talosMachineResource{}
+	_ resource.ResourceWithImportState    = &talosMachineResource{}
 )
 
 type talosMachineResourceModel struct {
@@ -550,41 +552,15 @@ func (r *talosMachineResource) Read(ctx context.Context, req resource.ReadReques
 	// one-time config re-apply. The re-apply is safe: the config is unchanged
 	// and Talos will not reboot for a no-op. No StateUpgraders migration is
 	// provided since only alpha versions are affected.
-	_ = talosClientOp(ctx, endpoint, state.Node.ValueString(), talosConfig, func(nodeCtx context.Context, c *client.Client) error { //nolint:errcheck
-		cfg, err := safe.StateGet[*configresource.MachineConfig](
-			nodeCtx,
-			c.COSI,
-			cosiresource.NewMetadata(
-				configresource.NamespaceName,
-				configresource.MachineConfigType,
-				configresource.ActiveID,
-				cosiresource.VersionUndefined,
-			),
-		)
-		if err != nil {
-			return err
-		}
-
-		yamlBytes, err := cfg.Provider().Bytes()
-		if err != nil {
-			return err
-		}
-
-		// Both Read (COSI bytes) and ModifyPlan (provider-rendered bytes) go
-		// through computeConfigHash's yaml.Marshal normalization, so key
-		// ordering is consistent on both sides. The two byte sources are
-		// semantically identical as long as Talos does not inject extra default
-		// fields when serializing — which is the case for configs written by
-		// this provider.
-		cfgHash, stripped := computeConfigHash(yamlBytes, state.IgnoreKubernetesUpgradeDrift.ValueBool())
-		if !stripped {
-			tflog.Warn(nodeCtx, "computeConfigHash: failed to normalize config; hash covers raw config bytes")
-		}
-
+	if cfgHash, err := talosMachineLiveConfigHash(
+		ctx,
+		endpoint,
+		state.Node.ValueString(),
+		talosConfig,
+		state.IgnoreKubernetesUpgradeDrift.ValueBool(),
+	); err == nil {
 		state.MachineConfigurationHash = types.StringValue(cfgHash)
-
-		return nil
-	})
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -645,10 +621,23 @@ func (r *talosMachineResource) Update(ctx context.Context, req resource.UpdateRe
 	plan.Endpoint = types.StringValue(endpoint)
 
 	// Upgrade OS first so the new config is accepted by the upgraded node.
+	// Post-import state has a null image (identity-only ImportState). Use
+	// UpgradeIfNeeded only then so filling the same running tag into state does
+	// not pull/install/drain/reboot. For every other image change (including
+	// same tag / different schematic), always upgrade — UpgradeIfNeeded is
+	// tag-only via replaceImageTag and would skip schematic updates (b812b76).
 	imageChanged := !plan.Image.IsNull() && !plan.Image.Equal(state.Image)
+	postImportAdopt := state.Image.IsNull()
 
 	if imageChanged {
-		if err := talosMachineUpgrade(ctxDeadline, endpoint, plan.Node.ValueString(), talosConfig, &plan); err != nil {
+		if err := talosMachineUpgradeOnUpdate(
+			ctxDeadline,
+			endpoint,
+			plan.Node.ValueString(),
+			talosConfig,
+			&plan,
+			postImportAdopt,
+		); err != nil {
 			resp.Diagnostics.AddError("error upgrading Talos", err.Error())
 
 			return
@@ -666,20 +655,39 @@ func (r *talosMachineResource) Update(ctx context.Context, req resource.UpdateRe
 			return
 		}
 
-		// Skip config apply if the normalized hash is unchanged. This covers two
-		// cases: (1) write-only machine_configuration_wo, where ModifyPlan cannot
-		// read the config and always marks hash Unknown; and (2) a simultaneous
-		// Talos OS upgrade where kubernetes_version also changed — the OS upgrade
-		// already happened above; with ignore_kubernetes_upgrade_drift=true, K8s
-		// images are excluded from the hash and must not be re-applied here, which
-		// would bypass upgrade-k8s's sequential safety procedure.
+		// Skip config apply if the normalized hash is unchanged. This covers:
+		// (1) write-only machine_configuration_wo, where ModifyPlan cannot read
+		// the config and always marks hash Unknown; (2) a simultaneous Talos OS
+		// upgrade where kubernetes_version also changed — with
+		// ignore_kubernetes_upgrade_drift=true, K8s images are excluded from the
+		// hash and must not be re-applied here; (3) post-import adopt, where
+		// state hash is empty — compare against the live COSI config so filling
+		// HCL into state does not re-apply an identical machine config.
 		configHash, stripped := computeConfigHash(cfgBytes, plan.IgnoreKubernetesUpgradeDrift.ValueBool())
 		if !stripped {
 			tflog.Warn(ctx, "computeConfigHash: failed to normalize config; hash covers raw config bytes")
 		}
 
-		if configHash == state.MachineConfigurationHash.ValueString() {
-			plan.MachineConfigurationHash = state.MachineConfigurationHash
+		baselineHash, baselineErr := talosMachineConfigBaselineHash(
+			ctxDeadline,
+			endpoint,
+			plan.Node.ValueString(),
+			talosConfig,
+			state.MachineConfigurationHash.ValueString(),
+			plan.IgnoreKubernetesUpgradeDrift.ValueBool(),
+			postImportAdopt,
+		)
+		if baselineErr != nil {
+			resp.Diagnostics.AddError(
+				"error reading live machine configuration for adopt/update",
+				baselineErr.Error(),
+			)
+
+			return
+		}
+
+		if configHash == baselineHash {
+			plan.MachineConfigurationHash = types.StringValue(configHash)
 			resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
 			return
@@ -749,6 +757,57 @@ func (r *talosMachineResource) Delete(ctx context.Context, req resource.DeleteRe
 	).Run(ctx); err != nil {
 		resp.Diagnostics.AddError("error resetting machine", err.Error())
 	}
+}
+
+func (r *talosMachineResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	node := strings.TrimSpace(req.ID)
+	if node == "" {
+		resp.Diagnostics.AddError(
+			"failed to import state",
+			"import ID must be the Talos node IP address or hostname",
+		)
+
+		return
+	}
+
+	timeout, diag := basetypes.NewObjectValue(map[string]attr.Type{
+		"create": types.StringType,
+		"update": types.StringType,
+		"delete": types.StringType,
+	}, map[string]attr.Value{
+		"create": basetypes.NewStringNull(),
+		"update": basetypes.NewStringNull(),
+		"delete": basetypes.NewStringNull(),
+	})
+	resp.Diagnostics.Append(diag...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Import only records identity. Read cannot see HCL client_configuration, so
+	// image / machine_configuration_hash are filled on the first Update by
+	// observing the live node (UpgradeIfNeeded + live COSI hash compare) before
+	// any apply/upgrade. Do not treat a post-import plan "update in-place" as a
+	// license to mutate the node when HCL already matches reality.
+	clientConfig := basetypes.NewObjectNull(map[string]attr.Type{
+		"ca_certificate":     types.StringType,
+		"client_certificate": types.StringType,
+		"client_key":         types.StringType,
+	})
+
+	state := talosMachineResourceModel{
+		ID:                    basetypes.NewStringValue(node),
+		Node:                  basetypes.NewStringValue(node),
+		Endpoint:              basetypes.NewStringValue(node),
+		ClientConfiguration:   clientConfig,
+		ClientConfigurationWO: clientConfig, // write-only: always null in state; typed null required by ObjectType
+		Timeouts: timeouts.Value{
+			Object: timeout,
+		},
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 // talosMachineApplyConfig applies the machine configuration with retry and waits for
@@ -857,6 +916,23 @@ func talosMachineUpgradeIfNeeded(ctx context.Context, endpoint, node string, tal
 	}
 
 	return talosMachineUpgrade(ctx, endpoint, node, talosConfig, state)
+}
+
+// talosMachineUpgradeOnUpdate chooses UpgradeIfNeeded only for post-import adopt
+// (null prior image). All other Update image changes use unconditional Upgrade
+// so same-tag schematic changes are not skipped.
+func talosMachineUpgradeOnUpdate(
+	ctx context.Context,
+	endpoint, node string,
+	talosConfig *clientconfig.Config,
+	plan *talosMachineResourceModel,
+	postImportAdopt bool,
+) error {
+	if postImportAdopt {
+		return talosMachineUpgradeIfNeeded(ctx, endpoint, node, talosConfig, plan)
+	}
+
+	return talosMachineUpgrade(ctx, endpoint, node, talosConfig, plan)
 }
 
 func talosMachineRunningVersion(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, desiredImage string) (string, error) {
@@ -1118,6 +1194,81 @@ func replaceImageTag(imageRef, newTag string) string {
 	}
 
 	return imageRef + ":" + newTag
+}
+
+// talosMachineLiveConfigHash reads the active machine config from COSI and returns
+// the same normalized hash ModifyPlan / Update use for drift detection.
+func talosMachineLiveConfigHash(
+	ctx context.Context,
+	endpoint, node string,
+	talosConfig *clientconfig.Config,
+	suppressK8sDrift bool,
+) (string, error) {
+	var cfgHash string
+
+	if err := talosClientOp(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
+		cfg, err := safe.StateGet[*configresource.MachineConfig](
+			nodeCtx,
+			c.COSI,
+			cosiresource.NewMetadata(
+				configresource.NamespaceName,
+				configresource.MachineConfigType,
+				configresource.ActiveID,
+				cosiresource.VersionUndefined,
+			),
+		)
+		if err != nil {
+			return err
+		}
+
+		yamlBytes, err := cfg.Provider().Bytes()
+		if err != nil {
+			return err
+		}
+
+		// Both Read (COSI bytes) and ModifyPlan (provider-rendered bytes) go
+		// through computeConfigHash's yaml.Marshal normalization, so key
+		// ordering is consistent on both sides. The two byte sources are
+		// semantically identical as long as Talos does not inject extra default
+		// fields when serializing — which is the case for configs written by
+		// this provider.
+		hash, stripped := computeConfigHash(yamlBytes, suppressK8sDrift)
+		if !stripped {
+			tflog.Warn(nodeCtx, "computeConfigHash: failed to normalize config; hash covers raw config bytes")
+		}
+
+		cfgHash = hash
+
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	return cfgHash, nil
+}
+
+// talosMachineConfigBaselineHash returns the hash Update should compare against.
+// Post-import adopt (empty state hash + null prior image) requires a live COSI
+// read and errors if unavailable. Other empty-hash cases keep prior behavior:
+// empty baseline so desired config is applied.
+func talosMachineConfigBaselineHash(
+	ctx context.Context,
+	endpoint, node string,
+	talosConfig *clientconfig.Config,
+	stateHash string,
+	suppressK8sDrift bool,
+	postImportAdopt bool,
+) (string, error) {
+	if stateHash != "" || !postImportAdopt {
+		return stateHash, nil
+	}
+
+	liveHash, err := talosMachineLiveConfigHash(ctx, endpoint, node, talosConfig, suppressK8sDrift)
+	if err != nil {
+		return "", fmt.Errorf("state has no machine_configuration_hash; refused to apply without comparing to the node: %w", err)
+	}
+
+	return liveHash, nil
 }
 
 // resolveTalosMachineClientConfig builds the Talos client config from either the

--- a/pkg/talos/talos_machine_resource.go
+++ b/pkg/talos/talos_machine_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -61,6 +62,7 @@ var (
 	_ resource.Resource                   = &talosMachineResource{}
 	_ resource.ResourceWithModifyPlan     = &talosMachineResource{}
 	_ resource.ResourceWithValidateConfig = &talosMachineResource{}
+	_ resource.ResourceWithImportState    = &talosMachineResource{}
 )
 
 type talosMachineResourceModel struct {
@@ -550,41 +552,15 @@ func (r *talosMachineResource) Read(ctx context.Context, req resource.ReadReques
 	// one-time config re-apply. The re-apply is safe: the config is unchanged
 	// and Talos will not reboot for a no-op. No StateUpgraders migration is
 	// provided since only alpha versions are affected.
-	_ = talosClientOp(ctx, endpoint, state.Node.ValueString(), talosConfig, func(nodeCtx context.Context, c *client.Client) error { //nolint:errcheck
-		cfg, err := safe.StateGet[*configresource.MachineConfig](
-			nodeCtx,
-			c.COSI,
-			cosiresource.NewMetadata(
-				configresource.NamespaceName,
-				configresource.MachineConfigType,
-				configresource.ActiveID,
-				cosiresource.VersionUndefined,
-			),
-		)
-		if err != nil {
-			return err
-		}
-
-		yamlBytes, err := cfg.Provider().Bytes()
-		if err != nil {
-			return err
-		}
-
-		// Both Read (COSI bytes) and ModifyPlan (provider-rendered bytes) go
-		// through computeConfigHash's yaml.Marshal normalization, so key
-		// ordering is consistent on both sides. The two byte sources are
-		// semantically identical as long as Talos does not inject extra default
-		// fields when serializing — which is the case for configs written by
-		// this provider.
-		cfgHash, stripped := computeConfigHash(yamlBytes, state.IgnoreKubernetesUpgradeDrift.ValueBool())
-		if !stripped {
-			tflog.Warn(nodeCtx, "computeConfigHash: failed to normalize config; hash covers raw config bytes")
-		}
-
+	if cfgHash, err := talosMachineLiveConfigHash(
+		ctx,
+		endpoint,
+		state.Node.ValueString(),
+		talosConfig,
+		state.IgnoreKubernetesUpgradeDrift.ValueBool(),
+	); err == nil {
 		state.MachineConfigurationHash = types.StringValue(cfgHash)
-
-		return nil
-	})
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -645,10 +621,23 @@ func (r *talosMachineResource) Update(ctx context.Context, req resource.UpdateRe
 	plan.Endpoint = types.StringValue(endpoint)
 
 	// Upgrade OS first so the new config is accepted by the upgraded node.
+	// Post-import state has a null image (identity-only ImportState). Use
+	// UpgradeIfNeeded only then so filling the same running tag into state does
+	// not pull/install/drain/reboot. For every other image change (including
+	// same tag / different schematic), always upgrade — UpgradeIfNeeded is
+	// tag-only via replaceImageTag and would skip schematic updates (b812b76).
 	imageChanged := !plan.Image.IsNull() && !plan.Image.Equal(state.Image)
+	postImportAdopt := state.Image.IsNull()
 
 	if imageChanged {
-		if err := talosMachineUpgrade(ctxDeadline, endpoint, plan.Node.ValueString(), talosConfig, &plan); err != nil {
+		if err := talosMachineUpgradeOnUpdate(
+			ctxDeadline,
+			endpoint,
+			plan.Node.ValueString(),
+			talosConfig,
+			&plan,
+			postImportAdopt,
+		); err != nil {
 			resp.Diagnostics.AddError("error upgrading Talos", err.Error())
 
 			return
@@ -666,20 +655,39 @@ func (r *talosMachineResource) Update(ctx context.Context, req resource.UpdateRe
 			return
 		}
 
-		// Skip config apply if the normalized hash is unchanged. This covers two
-		// cases: (1) write-only machine_configuration_wo, where ModifyPlan cannot
-		// read the config and always marks hash Unknown; and (2) a simultaneous
-		// Talos OS upgrade where kubernetes_version also changed — the OS upgrade
-		// already happened above; with ignore_kubernetes_upgrade_drift=true, K8s
-		// images are excluded from the hash and must not be re-applied here, which
-		// would bypass upgrade-k8s's sequential safety procedure.
+		// Skip config apply if the normalized hash is unchanged. This covers:
+		// (1) write-only machine_configuration_wo, where ModifyPlan cannot read
+		// the config and always marks hash Unknown; (2) a simultaneous Talos OS
+		// upgrade where kubernetes_version also changed — with
+		// ignore_kubernetes_upgrade_drift=true, K8s images are excluded from the
+		// hash and must not be re-applied here; (3) post-import adopt, where
+		// state hash is empty — compare against the live COSI config so filling
+		// HCL into state does not re-apply an identical machine config.
 		configHash, stripped := computeConfigHash(cfgBytes, plan.IgnoreKubernetesUpgradeDrift.ValueBool())
 		if !stripped {
 			tflog.Warn(ctx, "computeConfigHash: failed to normalize config; hash covers raw config bytes")
 		}
 
-		if configHash == state.MachineConfigurationHash.ValueString() {
-			plan.MachineConfigurationHash = state.MachineConfigurationHash
+		baselineHash, baselineErr := talosMachineConfigBaselineHash(
+			ctxDeadline,
+			endpoint,
+			plan.Node.ValueString(),
+			talosConfig,
+			state.MachineConfigurationHash.ValueString(),
+			plan.IgnoreKubernetesUpgradeDrift.ValueBool(),
+			postImportAdopt,
+		)
+		if baselineErr != nil {
+			resp.Diagnostics.AddError(
+				"error reading live machine configuration for adopt/update",
+				baselineErr.Error(),
+			)
+
+			return
+		}
+
+		if configHash == baselineHash {
+			plan.MachineConfigurationHash = types.StringValue(configHash)
 			resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
 			return
@@ -749,6 +757,57 @@ func (r *talosMachineResource) Delete(ctx context.Context, req resource.DeleteRe
 	).Run(ctx); err != nil {
 		resp.Diagnostics.AddError("error resetting machine", err.Error())
 	}
+}
+
+func (r *talosMachineResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	node := strings.TrimSpace(req.ID)
+	if node == "" {
+		resp.Diagnostics.AddError(
+			"failed to import state",
+			"import ID must be the Talos node IP address or hostname",
+		)
+
+		return
+	}
+
+	timeout, diag := basetypes.NewObjectValue(map[string]attr.Type{
+		"create": types.StringType,
+		"update": types.StringType,
+		"delete": types.StringType,
+	}, map[string]attr.Value{
+		"create": basetypes.NewStringNull(),
+		"update": basetypes.NewStringNull(),
+		"delete": basetypes.NewStringNull(),
+	})
+	resp.Diagnostics.Append(diag...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Import only records identity. Read cannot see HCL client_configuration, so
+	// image / machine_configuration_hash are filled on the first Update by
+	// observing the live node (UpgradeIfNeeded + live COSI hash compare) before
+	// any apply/upgrade. Do not treat a post-import plan "update in-place" as a
+	// license to mutate the node when HCL already matches reality.
+	clientConfig := basetypes.NewObjectNull(map[string]attr.Type{
+		"ca_certificate":     types.StringType,
+		"client_certificate": types.StringType,
+		"client_key":         types.StringType,
+	})
+
+	state := talosMachineResourceModel{
+		ID:                    basetypes.NewStringValue(node),
+		Node:                  basetypes.NewStringValue(node),
+		Endpoint:              basetypes.NewStringValue(node),
+		ClientConfiguration:   clientConfig,
+		ClientConfigurationWO: clientConfig, // write-only: always null in state; typed null required by ObjectType
+		Timeouts: timeouts.Value{
+			Object: timeout,
+		},
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 // talosMachineApplyConfig applies the machine configuration with retry and waits for
@@ -857,6 +916,23 @@ func talosMachineUpgradeIfNeeded(ctx context.Context, endpoint, node string, tal
 	}
 
 	return talosMachineUpgrade(ctx, endpoint, node, talosConfig, state)
+}
+
+// talosMachineUpgradeOnUpdate chooses UpgradeIfNeeded only for post-import adopt
+// (null prior image). All other Update image changes use unconditional Upgrade
+// so same-tag schematic changes are not skipped.
+func talosMachineUpgradeOnUpdate(
+	ctx context.Context,
+	endpoint, node string,
+	talosConfig *clientconfig.Config,
+	plan *talosMachineResourceModel,
+	postImportAdopt bool,
+) error {
+	if postImportAdopt {
+		return talosMachineUpgradeIfNeeded(ctx, endpoint, node, talosConfig, plan)
+	}
+
+	return talosMachineUpgrade(ctx, endpoint, node, talosConfig, plan)
 }
 
 func talosMachineRunningVersion(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, desiredImage string) (string, error) {
@@ -1165,6 +1241,81 @@ func replaceImageTag(imageRef, newTag string) string {
 	}
 
 	return imageRef + ":" + newTag
+}
+
+// talosMachineLiveConfigHash reads the active machine config from COSI and returns
+// the same normalized hash ModifyPlan / Update use for drift detection.
+func talosMachineLiveConfigHash(
+	ctx context.Context,
+	endpoint, node string,
+	talosConfig *clientconfig.Config,
+	suppressK8sDrift bool,
+) (string, error) {
+	var cfgHash string
+
+	if err := talosClientOp(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
+		cfg, err := safe.StateGet[*configresource.MachineConfig](
+			nodeCtx,
+			c.COSI,
+			cosiresource.NewMetadata(
+				configresource.NamespaceName,
+				configresource.MachineConfigType,
+				configresource.ActiveID,
+				cosiresource.VersionUndefined,
+			),
+		)
+		if err != nil {
+			return err
+		}
+
+		yamlBytes, err := cfg.Provider().Bytes()
+		if err != nil {
+			return err
+		}
+
+		// Both Read (COSI bytes) and ModifyPlan (provider-rendered bytes) go
+		// through computeConfigHash's yaml.Marshal normalization, so key
+		// ordering is consistent on both sides. The two byte sources are
+		// semantically identical as long as Talos does not inject extra default
+		// fields when serializing — which is the case for configs written by
+		// this provider.
+		hash, stripped := computeConfigHash(yamlBytes, suppressK8sDrift)
+		if !stripped {
+			tflog.Warn(nodeCtx, "computeConfigHash: failed to normalize config; hash covers raw config bytes")
+		}
+
+		cfgHash = hash
+
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	return cfgHash, nil
+}
+
+// talosMachineConfigBaselineHash returns the hash Update should compare against.
+// Post-import adopt (empty state hash + null prior image) requires a live COSI
+// read and errors if unavailable. Other empty-hash cases keep prior behavior:
+// empty baseline so desired config is applied.
+func talosMachineConfigBaselineHash(
+	ctx context.Context,
+	endpoint, node string,
+	talosConfig *clientconfig.Config,
+	stateHash string,
+	suppressK8sDrift bool,
+	postImportAdopt bool,
+) (string, error) {
+	if stateHash != "" || !postImportAdopt {
+		return stateHash, nil
+	}
+
+	liveHash, err := talosMachineLiveConfigHash(ctx, endpoint, node, talosConfig, suppressK8sDrift)
+	if err != nil {
+		return "", fmt.Errorf("state has no machine_configuration_hash; refused to apply without comparing to the node: %w", err)
+	}
+
+	return liveHash, nil
 }
 
 // resolveTalosMachineClientConfig builds the Talos client config from either the

--- a/pkg/talos/talos_machine_resource_internal_test.go
+++ b/pkg/talos/talos_machine_resource_internal_test.go
@@ -11,7 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 )
@@ -49,5 +52,113 @@ func TestLegacyUpgrade_ImmediateRPCError_AbortsPollEarly(t *testing.T) {
 	// path. Its presence proves the goroutine error reached the poll loop.
 	if !strings.Contains(err.Error(), "upgrade RPC failed:") {
 		t.Fatalf("expected 'upgrade RPC failed:' in error message, got: %v", err)
+	}
+}
+
+func TestTalosMachineResource_ImportState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := &talosMachineResource{}
+
+	var schemaResp resource.SchemaResponse
+
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	schTFType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema TerraformType is not tftypes.Object")
+	}
+
+	t.Run("sets id node and endpoint from import id", func(t *testing.T) {
+		t.Parallel()
+
+		importResp := &resource.ImportStateResponse{
+			State: tfsdk.State{
+				Schema: schemaResp.Schema,
+				Raw:    tftypes.NewValue(schTFType, nil),
+			},
+		}
+
+		r.ImportState(ctx, resource.ImportStateRequest{ID: "10.5.0.2"}, importResp)
+
+		if importResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", importResp.Diagnostics)
+		}
+
+		var state talosMachineResourceModel
+
+		diags := importResp.State.Get(ctx, &state)
+		if diags.HasError() {
+			t.Fatalf("failed to read imported state: %v", diags)
+		}
+
+		if state.ID.ValueString() != "10.5.0.2" {
+			t.Fatalf("expected id 10.5.0.2, got %q", state.ID.ValueString())
+		}
+
+		if state.Node.ValueString() != "10.5.0.2" {
+			t.Fatalf("expected node 10.5.0.2, got %q", state.Node.ValueString())
+		}
+
+		if state.Endpoint.ValueString() != "10.5.0.2" {
+			t.Fatalf("expected endpoint 10.5.0.2, got %q", state.Endpoint.ValueString())
+		}
+
+		if !state.Image.IsNull() {
+			t.Fatalf("expected image null after import (post-import adopt signal), got %v", state.Image)
+		}
+
+		if !state.MachineConfigurationHash.IsNull() && state.MachineConfigurationHash.ValueString() != "" {
+			t.Fatalf("expected empty machine_configuration_hash after import, got %q", state.MachineConfigurationHash.ValueString())
+		}
+
+		if !state.ClientConfigurationWO.IsNull() {
+			t.Fatalf("expected client_configuration_wo null after import, got %v", state.ClientConfigurationWO)
+		}
+	})
+
+	t.Run("rejects empty import id", func(t *testing.T) {
+		t.Parallel()
+
+		importResp := &resource.ImportStateResponse{
+			State: tfsdk.State{
+				Schema: schemaResp.Schema,
+				Raw:    tftypes.NewValue(schTFType, nil),
+			},
+		}
+
+		r.ImportState(ctx, resource.ImportStateRequest{ID: "  "}, importResp)
+
+		if !importResp.Diagnostics.HasError() {
+			t.Fatal("expected error for empty import id")
+		}
+	})
+}
+
+// TestReplaceImageTag_PreservesRepository documents why Update must not use
+// UpgradeIfNeeded for non-import image changes: running version is reconstructed
+// as desiredRepo:runningTag, so same tag / different schematic compares equal.
+func TestReplaceImageTag_PreservesRepository(t *testing.T) {
+	t.Parallel()
+
+	desired := "factory.talos.dev/installer/c9078f94abcdef:v1.13.0"
+	running := replaceImageTag(desired, "v1.13.0")
+
+	if running != desired {
+		t.Fatalf("replaceImageTag should keep desired repository, got %q want %q", running, desired)
+	}
+
+	otherSchematic := "factory.talos.dev/installer/376567abcdef:v1.13.0"
+	runningFromOther := replaceImageTag(otherSchematic, "v1.13.0")
+
+	if runningFromOther != otherSchematic {
+		t.Fatalf("got %q want %q", runningFromOther, otherSchematic)
+	}
+
+	// UpgradeIfNeeded would treat these as equal when the node reports tag v1.13.0
+	// while desired is otherSchematic — both become otherSchematic:v1.13.0.
+	if replaceImageTag(otherSchematic, "v1.13.0") != otherSchematic {
+		t.Fatal("unexpected replaceImageTag behavior")
 	}
 }

--- a/pkg/talos/talos_machine_resource_test.go
+++ b/pkg/talos/talos_machine_resource_test.go
@@ -23,12 +23,52 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/siderolabs/talos/pkg/images"
 	"github.com/siderolabs/talos/pkg/machinery/gendata"
 
 	"github.com/siderolabs/terraform-provider-talos/pkg/talos"
 )
+
+// TestAccTalosMachine_import verifies importing an existing node by address.
+// Import only seeds id/node/endpoint; credentials and machine configuration come
+// from HCL after import. A follow-up apply is not exercised here because Update
+// contacts the node (unlike talos_machine_bootstrap's no-op Update).
+func TestAccTalosMachine_import(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		IsUnitTest:               true, // import can be unit tested
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccTalosMachineResourceConfigImport("10.5.0.2"),
+				ResourceName:       "talos_machine.this",
+				ImportStateId:      "10.5.0.2",
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateCheck: func(is []*terraform.InstanceState) error {
+					if len(is) != 1 {
+						return fmt.Errorf("expected 1 state, got %d", len(is))
+					}
+
+					if is[0].ID != "10.5.0.2" {
+						return fmt.Errorf("expected id %q, got %q", "10.5.0.2", is[0].ID)
+					}
+
+					if got := is[0].Attributes["node"]; got != "10.5.0.2" {
+						return fmt.Errorf("expected node %q, got %q", "10.5.0.2", got)
+					}
+
+					if got := is[0].Attributes["endpoint"]; got != "10.5.0.2" {
+						return fmt.Errorf("expected endpoint %q, got %q", "10.5.0.2", got)
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
 
 // TestAccTalosMachine_bootstrap applies machine configuration via talos_machine,
 // bootstraps etcd, waits for cluster health, and confirms idempotency.
@@ -825,6 +865,27 @@ const (
 	cpuModeDefault = "host-passthrough"
 	cpuModeCI      = "host-model"
 )
+
+func testAccTalosMachineResourceConfigImport(node string) string {
+	return fmt.Sprintf(`
+resource "talos_machine_secrets" "this" {}
+
+data "talos_machine_configuration" "this" {
+  cluster_name     = "example-cluster"
+  machine_type     = "controlplane"
+  cluster_endpoint = "https://%s:6443"
+  machine_secrets  = talos_machine_secrets.this.machine_secrets
+  docs             = false
+  examples         = false
+}
+
+resource "talos_machine" "this" {
+  node                  = "%s"
+  client_configuration  = talos_machine_secrets.this.client_configuration
+  machine_configuration = data.talos_machine_configuration.this.machine_configuration
+}
+`, node, node)
+}
 
 func testAccTalosMachineConfig(rName, imageUrl, imageTag, isoVersion string) string {
 	cpuMode := cpuModeDefault

--- a/pkg/talos/talos_machine_resource_test.go
+++ b/pkg/talos/talos_machine_resource_test.go
@@ -36,6 +36,45 @@ import (
 	"github.com/siderolabs/terraform-provider-talos/pkg/talos"
 )
 
+// TestAccTalosMachine_import verifies importing an existing node by address.
+// Import only seeds id/node/endpoint; credentials and machine configuration come
+// from HCL after import. A follow-up apply is not exercised here because Update
+// contacts the node (unlike talos_machine_bootstrap's no-op Update).
+func TestAccTalosMachine_import(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		IsUnitTest:               true, // import can be unit tested
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccTalosMachineResourceConfigImport("10.5.0.2"),
+				ResourceName:       "talos_machine.this",
+				ImportStateId:      "10.5.0.2",
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateCheck: func(is []*terraform.InstanceState) error {
+					if len(is) != 1 {
+						return fmt.Errorf("expected 1 state, got %d", len(is))
+					}
+
+					if is[0].ID != "10.5.0.2" {
+						return fmt.Errorf("expected id %q, got %q", "10.5.0.2", is[0].ID)
+					}
+
+					if got := is[0].Attributes["node"]; got != "10.5.0.2" {
+						return fmt.Errorf("expected node %q, got %q", "10.5.0.2", got)
+					}
+
+					if got := is[0].Attributes["endpoint"]; got != "10.5.0.2" {
+						return fmt.Errorf("expected endpoint %q, got %q", "10.5.0.2", got)
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
 // TestAccTalosMachine_bootstrap applies machine configuration via talos_machine,
 // bootstraps etcd, waits for cluster health, and confirms idempotency.
 func TestAccTalosMachine_bootstrap(t *testing.T) {
@@ -888,6 +927,27 @@ func installDiskPatch(talosVersion, image string) string {
 		"        diskSelector = {\n" +
 		fmt.Sprintf("          match = %q\n", "disk.dev_path == '"+devPath+"'") +
 		"        }\n      }\n    })"
+}
+
+func testAccTalosMachineResourceConfigImport(node string) string {
+	return fmt.Sprintf(`
+resource "talos_machine_secrets" "this" {}
+
+data "talos_machine_configuration" "this" {
+  cluster_name     = "example-cluster"
+  machine_type     = "controlplane"
+  cluster_endpoint = "https://%s:6443"
+  machine_secrets  = talos_machine_secrets.this.machine_secrets
+  docs             = false
+  examples         = false
+}
+
+resource "talos_machine" "this" {
+  node                  = "%s"
+  client_configuration  = talos_machine_secrets.this.client_configuration
+  machine_configuration = data.talos_machine_configuration.this.machine_configuration
+}
+`, node, node)
 }
 
 func testAccTalosMachineConfig(rName, imageUrl, imageTag, isoVersion string) string {

--- a/templates/resources/machine.md.tmpl
+++ b/templates/resources/machine.md.tmpl
@@ -105,3 +105,65 @@ With `ignore_kubernetes_upgrade_drift = true`:
 If you use `talos_machine` without `talos_cluster`, leave `ignore_kubernetes_upgrade_drift` unset and run `talosctl upgrade-k8s` manually to upgrade Kubernetes.
 
 {{ .SchemaMarkdown | trimspace }}
+
+{{ if .HasImport }}
+## Import
+
+Talos machines can be imported using the node IP address or hostname, e.g.
+
+```shell
+terraform import talos_machine.example 10.5.0.2
+```
+
+### Prerequisites
+
+Import only records identity (`id`, `node`, `endpoint`). It does not read
+certificates from the node.
+
+**Provider version:** `talos_machine` exists from provider **v0.12.0-alpha.0**
+onward. Import support for this resource requires a provider build that includes
+`ImportState` for `talos_machine` (this feature). The cluster itself does not
+need to have been created by that same provider version. A common path is to
+create the cluster with **v0.11.x** (`talos_machine_configuration_apply` +
+bootstrap + secrets), then adopt the node with a **v0.12+** provider that
+supports `talos_machine` import.
+
+**Credentials in state:** Wire `client_configuration` from an existing secrets
+resource (typical when migrating off `talos_machine_configuration_apply`):
+
+```terraform
+resource "talos_machine" "example" {
+  node                 = "10.5.0.2"
+  client_configuration = talos_machine_secrets.this.client_configuration
+  # ...
+}
+```
+
+`talos_machine_secrets` should already be in state (or import it first with
+`terraform import talos_machine_secrets.this <path-to-secrets.yaml>`).
+
+**Import ID must match `node`:** `node` has `RequiresReplace`. The import ID
+becomes both `id` and `node` in state. If HCL `node` does not match that value
+exactly (for example import by IP but configure a hostname, or the reverse), the
+first plan is a **destroy/create** of the live machine instead of an in-place
+state fill. Use the same address string in the import ID and in `node`.
+
+### What to expect after import
+
+1. `terraform state show` lists `id` / `node` / `endpoint` only at first.
+2. `terraform plan` shows an **in-place update** that fills attributes from HCL
+   (`client_configuration`, `image`, `machine_configuration`, flags such as
+   `drain_on_upgrade`, and so on). That is expected when import ID matches `node`.
+   It does **not** mean Terraform will recreate the VM or that those values are
+   missing from the cluster.
+3. `terraform apply` of that plan copies HCL into this resource's state. On that
+   post-import apply (state `image` is null), the provider observes the live
+   machine first: it skips OS upgrade when the running version already matches
+   `image`, and skips machine-config apply when the live config hash already
+   matches. Later applies that change `image` always upgrade (including same tag
+   with a new schematic). If HCL differs from the node, apply upgrades or
+   re-applies as usual.
+4. A following `terraform plan` should report no changes when configuration matches
+   the node.
+
+{{ end }}


### PR DESCRIPTION
## Summary

- Add `ImportState` for `talos_machine` so existing nodes (typically created with `talos_machine_configuration_apply` on provider v0.11.x) can be adopted by IP/hostname without recreating the cluster.
- Import records identity only (`id` / `node` / `endpoint`). Remaining attributes are filled from HCL on the first apply (credentials normally already live on `talos_machine_secrets` in state).
- Harden `Update` for that post-import apply: use `UpgradeIfNeeded` for `image`, and when state has no config hash, compare against the live COSI hash before `ApplyConfiguration`, so matching HCL only updates state.
- Document import prerequisites and expected plan/apply behavior; add `examples/resources/talos_machine/import.sh`.

## Why identity-only import (not a full azurerm-style hydrate)

Terraform Plugin Framework `ImportState` / the following `Read` do **not** receive the resource's HCL `Config`. For `talos_machine`, Talos API access is keyed off `client_configuration` on the **resource** (unlike azurerm AKS, where ARM credentials live on the **provider** and `Read` can hydrate everything from Azure after import).

So at import time the provider has the node address, but not the client certs, and cannot call Version/COSI to populate `image` / `machine_configuration_hash` yet.

**Intended migration path:** `talos_machine_secrets` is already in state from the prior apply-based cluster. HCL keeps:

```hcl
client_configuration = talos_machine_secrets.this.client_configuration
```

The first plan after import therefore shows an in-place update that copies those certs (and `image`, config, flags) onto `talos_machine` state. That is expected and documented; it is not a destroy/recreate.

## Do we care about node / OS version on import?

**Yes**, but not inside `ImportState`.

On the first `Update` after import we **observe the live node before mutating**:

- `image`: `UpgradeIfNeeded` (skip pull/install/drain/reboot when the running version already matches)
- machine config: if state hash is empty, read the live COSI hash and skip `ApplyConfiguration` when it matches HCL

So a post-import apply whose HCL matches the cluster should only fill state (validated in lab: apply completed in ~0s). If HCL differs, apply upgrades or re-applies as usual.

We deliberately did **not** require importing `client_configuration` from a file/env in v1 of this feature: secrets are already in state for the common adopt path, and cross-resource state copy during import is not supported by the Terraform provider protocol.

## Problem

Without import, moving from `talos_machine_configuration_apply` to `talos_machine` (required for Terraform-managed OS upgrades via `image`) forced recreation or an unsafe first apply that could treat empty state as an image/config change (unconditional upgrade / apply).

## Test plan

- [x] Unit: `TestTalosMachineResource_ImportState`
- [x] Unit/ACC stub: `TestAccTalosMachine_import` (`IsUnitTest`; import does not contact the node)
- [x] `go test ./pkg/talos/ -run 'TestTalosMachineResource_ImportState|TestAccTalosMachine_import'`
- [x] `golangci-lint run ./pkg/talos/...` (0 issues)
- [x] `make generate` / docs regenerated from templates
- [x] Live lab (libvirt nested ACC host): Phase A deploy on v0.11.0 / Talos v1.12.7 → import with custom build → post-import apply (0s, state fill only) → Phase C OS upgrade to Talos v1.13.5 via `image` (~1.5m); members and state show `v1.13.5`
- [ ] CI `acceptance-tests` / `check-dirty` (pending workflow approval on fork PR)

## Notes

- Conform/history style: single conventional commit, DCO (`Signed-off-by`), GPG-signed.
- `conform/commit/gpg-identity` may fail for external contributors (`openpgp: signature made by unknown entity`); DCO and GPG-present checks already pass.