### PR TITLE
chore(test): fetch boot ISOs from Image Factory instead of GitHub releases

### DIFF
--- a/pkg/talos/provider_test.go
+++ b/pkg/talos/provider_test.go
@@ -39,7 +39,20 @@ type dynamicConfig struct {
 const (
 	cpuModeHostPassthrough = "host-passthrough"
 	cpuModeHostModel       = "host-model"
+
+	// emptySchematicID is Image Factory's schematic with no customisations, i.e. a stock
+	// Talos image. Same ID the image factory data sources are asserted against.
+	emptySchematicID = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
 )
+
+// talosISOURL is the boot ISO for a Talos version.
+//
+// Served by Image Factory rather than the GitHub release: qemu fetches this URL directly
+// for every domain, and Image Factory is behind a CDN whereas GitHub release downloads
+// are rate limited.
+func talosISOURL(version string) string {
+	return fmt.Sprintf("https://factory.talos.dev/image/%s/%s/metal-amd64.iso", emptySchematicID, version)
+}
 
 func (c *dynamicConfig) render() string {
 	cpuMode := cpuModeHostPassthrough
@@ -49,7 +62,7 @@ func (c *dynamicConfig) render() string {
 
 	c.CPUMode = cpuMode
 
-	c.IsoURL = fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso", gendata.VersionTag)
+	c.IsoURL = talosISOURL(gendata.VersionTag)
 
 	configTemplate := `
 resource "talos_machine_secrets" "this" {}

--- a/pkg/talos/talos_cluster_resource_test.go
+++ b/pkg/talos/talos_cluster_resource_test.go
@@ -102,10 +102,7 @@ func testAccTalosClusterConfig(rName, talosVersion, k8sVersion string) string {
 		cpuMode = cpuModeHostModel
 	}
 
-	isoURL := fmt.Sprintf(
-		"https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso",
-		talosVersion,
-	)
+	isoURL := talosISOURL(talosVersion)
 
 	installerBase := images.InstallerImageRepository("metal")
 
@@ -227,10 +224,7 @@ func testAccTalosClusterHAConfig(rName, talosVersion, k8sVersion string) string 
 		cpuMode = cpuModeHostModel
 	}
 
-	isoURL := fmt.Sprintf(
-		"https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso",
-		talosVersion,
-	)
+	isoURL := talosISOURL(talosVersion)
 
 	installerBase := images.InstallerImageRepository("metal")
 

--- a/pkg/talos/talos_machine_configuration_apply_resource_test.go
+++ b/pkg/talos/talos_machine_configuration_apply_resource_test.go
@@ -507,7 +507,7 @@ func testAccTalosMachineConfigurationApplyWithEphemeralClientConfigWOConfig(rNam
 		cpuMode = cpuModeHostModel
 	}
 
-	isoURL := fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso", gendata.VersionTag)
+	isoURL := talosISOURL(gendata.VersionTag)
 
 	return fmt.Sprintf(`
 # Generate ephemeral machine secrets (NOT persisted - causes expected drift)

--- a/pkg/talos/talos_machine_resource_test.go
+++ b/pkg/talos/talos_machine_resource_test.go
@@ -127,10 +127,7 @@ func testAccTalosMachineWorkerDrainConfig(rName, cpImageTag, workerImageTag stri
 
 	// Both CP and worker boot from the same base ISO. The worker upgrade target
 	// is controlled via talos_machine.image, not the ISO URL.
-	isoURL := fmt.Sprintf(
-		"https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso",
-		cpImageTag,
-	)
+	isoURL := talosISOURL(cpImageTag)
 
 	installerBase := images.InstallerImageRepository("metal")
 
@@ -832,10 +829,7 @@ func testAccTalosMachineConfig(rName, imageUrl, imageTag, isoVersion string) str
 		cpuMode = cpuModeCI
 	}
 
-	isoURL := fmt.Sprintf(
-		"https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso",
-		isoVersion,
-	)
+	isoURL := talosISOURL(isoVersion)
 
 	return fmt.Sprintf(`
 resource "talos_machine_secrets" "this" {}
@@ -964,10 +958,7 @@ func testAccTalosMachineConfigWithWriteOnlyAttrs(rName, imageUrl, imageTag, isoV
 		cpuMode = cpuModeCI
 	}
 
-	isoURL := fmt.Sprintf(
-		"https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso",
-		isoVersion,
-	)
+	isoURL := talosISOURL(isoVersion)
 
 	return fmt.Sprintf(`
 ephemeral "talos_machine_secrets" "this" {}
@@ -1357,10 +1348,7 @@ func testAccTalosMachineConfigUpgradeAndK8sBump(rName, isoVersion, imageTag, k8s
 		cpuMode = cpuModeCI
 	}
 
-	isoURL := fmt.Sprintf(
-		"https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso",
-		isoVersion,
-	)
+	isoURL := talosISOURL(isoVersion)
 
 	return fmt.Sprintf(`
 resource "talos_machine_secrets" "this" {}
@@ -1473,10 +1461,7 @@ func testAccTalosMachineConfigK8sBumpNoBootstrap(rName, talosVersion, k8sVersion
 		cpuMode = cpuModeCI
 	}
 
-	isoURL := fmt.Sprintf(
-		"https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso",
-		talosVersion,
-	)
+	isoURL := talosISOURL(talosVersion)
 
 	installerBase := images.InstallerImageRepository("metal")
 


### PR DESCRIPTION
qemu fetches the domain's disk URL directly, so every acceptance-test domain pulls its boot ISO on each boot. Image Factory serves these from a CDN, whereas GitHub release downloads are rate limited — a recent run failed with `CURL: Error opening file: The requested URL returned error: 403` while fetching an ISO.

Uses the empty schematic (`3765679...`), the same one the image factory data source tests assert against, so the image is stock Talos. Verified all four versions the fixtures boot (`v1.14.0-beta.1`, `v1.13.0`, `v1.13.0-rc.0`, `v1.12.7`) are served.

Also collapses nine copies of the URL into one `talosISOURL` helper.

Reworked per review: originally this also mirrored the Terraform providers and cached the ISOs on the runner. Dropped both — @frezbo confirmed the GitHub rate limiting was a networking issue that has since been fixed, and pointing at the CDN removes the need for a local cache.