### PR TITLE
fix(talos_machine): detect legacy upgrade completion by boot ID

### DIFF
--- a/pkg/talos/talos_machine_resource.go
+++ b/pkg/talos/talos_machine_resource.go
@@ -1038,6 +1038,39 @@ func talosMachineReboot(ctx context.Context, endpoint, node string, talosConfig 
 	).Run(ctx)
 }
 
+// talosMachineBootID reads the node's boot ID, which the kernel regenerates on every boot.
+// Used to detect that a node has actually rebooted, the same signal
+// action.BootIDChangedPostCheckFn uses for the reboot and v1.13+ upgrade paths.
+func talosMachineBootID(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, op clientOpFunc) (string, error) {
+	var bootID string
+
+	if err := op(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
+		reader, err := c.Read(nodeCtx, "/proc/sys/kernel/random/boot_id")
+		if err != nil {
+			return err
+		}
+
+		defer reader.Close() //nolint:errcheck
+
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			return err
+		}
+
+		bootID = strings.TrimSpace(string(body))
+
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	if bootID == "" {
+		return "", errors.New("node returned an empty boot ID")
+	}
+
+	return bootID, nil
+}
+
 // talosMachineUpgradeLegacy handles Talos < 1.13 nodes where LifecycleService is not available.
 // MachineService.Upgrade combines install + reboot atomically. drain_on_upgrade is not applied
 // here — talosctl upgrade does not drain on the legacy path either.
@@ -1049,10 +1082,24 @@ func talosMachineUpgradeLegacy(ctx context.Context, endpoint, node string, talos
 
 	upgradeRebootMode := machineapi.UpgradeRequest_RebootMode(upgradeRebootModeVal)
 
+	// An upgrade always reboots, so a changed boot ID is what marks it complete. The
+	// running Talos version cannot be used: the image can change without the version
+	// changing (a new Image Factory schematic at the same tag), and replaceImageTag
+	// rebuilds the "running" image from the desired one, so it compared equal on the first
+	// poll and reported success before the upgrade had done anything. See issue #377.
+	// A node that cannot report its boot ID (older node, restricted role) falls back to
+	// waiting for the upgrade RPC itself to return.
+	preBootID, bootIDErr := talosMachineBootID(ctx, endpoint, node, talosConfig, op)
+	if bootIDErr != nil {
+		tflog.Warn(ctx, "could not read boot ID before upgrade; waiting for the upgrade RPC to return instead", map[string]any{
+			"error": bootIDErr.Error(),
+		})
+	}
+
 	// On Talos < v1.13, UpgradeWithOptions holds the gRPC connection open for the entire
 	// download+install duration (~30–45 min). The action.Tracker pattern can't be used here
 	// because the action function doesn't return until done, causing RST_STREAM timeouts.
-	// Instead, fire the RPC in a goroutine and independently poll for the version change.
+	// Instead, fire the RPC in a goroutine and independently poll for the reboot.
 	// The channel carries the first non-nil error so the poll loop can abort early if the
 	// RPC fails before the node even reboots (bad image ref, auth failure, etc.).
 	rpcErrCh := make(chan error, 1)
@@ -1068,38 +1115,38 @@ func talosMachineUpgradeLegacy(ctx context.Context, endpoint, node string, talos
 
 			return err
 		})
-		if err != nil {
-			rpcErrCh <- err
-		}
+		rpcErrCh <- err
 	}()
+
+	var rpcDone bool
 
 	if err := retry.RetryContext(ctx, 60*time.Minute, func() *retry.RetryError {
 		// Abort early if the upgrade RPC itself failed (e.g. bad image, auth error).
 		select {
 		case rpcErr := <-rpcErrCh:
-			return retry.NonRetryableError(fmt.Errorf("upgrade RPC failed: %w", rpcErr))
+			if rpcErr != nil {
+				return retry.NonRetryableError(fmt.Errorf("upgrade RPC failed: %w", rpcErr))
+			}
+
+			rpcDone = true
 		default:
 		}
 
-		err := op(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
-			versionResp, err := c.Version(nodeCtx)
-			if err != nil {
-				return err
-			}
-
-			if len(versionResp.Messages) == 0 {
-				return fmt.Errorf("no version messages from node")
-			}
-
-			running := replaceImageTag(state.Image.ValueString(), versionResp.Messages[0].Version.Tag)
-			if running == state.Image.ValueString() {
+		if preBootID == "" {
+			if rpcDone {
 				return nil
 			}
 
-			return fmt.Errorf("node running %s, waiting for %s", running, state.Image.ValueString())
-		})
+			return retry.RetryableError(fmt.Errorf("waiting for the upgrade to %s to finish", state.Image.ValueString()))
+		}
+
+		currentBootID, err := talosMachineBootID(ctx, endpoint, node, talosConfig, op)
 		if err != nil {
 			return retry.RetryableError(err)
+		}
+
+		if currentBootID == preBootID {
+			return retry.RetryableError(fmt.Errorf("node has not rebooted into %s yet", state.Image.ValueString()))
 		}
 
 		return nil

--- a/pkg/talos/talos_machine_resource_test.go
+++ b/pkg/talos/talos_machine_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/safe"
 	frameworkpath "github.com/hashicorp/terraform-plugin-framework/path"
 	frameworkresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -23,9 +24,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/siderolabs/talos/pkg/images"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/gendata"
+	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 
 	"github.com/siderolabs/terraform-provider-talos/pkg/talos"
 )
@@ -348,6 +353,9 @@ func TestAccTalosMachine_upgrade(t *testing.T) {
 	const (
 		baseVersion    = "v1.12.7"
 		upgradeVersion = "v1.13.0"
+		// Same version as baseVersion, different schematic — see step 2.
+		schematicImage = "factory.talos.dev/metal-installer/c9078f9419961640c712a8bf2bb9174933dfcf1da383fd8ea2b7dc21493f8bac"
+		schematicID    = "c9078f9419961640c712a8bf2bb9174933dfcf1da383fd8ea2b7dc21493f8bac"
 	)
 
 	baseImage := images.InstallerImageRepository("metal")
@@ -373,7 +381,25 @@ func TestAccTalosMachine_upgrade(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.talos_cluster_health.this", "id"),
 				),
 			},
-			// Step 2: upgrade to v1.13.0, cluster still healthy afterwards
+			// Step 2: change only the schematic, staying on baseVersion (issue #377).
+			// The node is pre-1.13 here, so talosMachineUpgrade falls back to
+			// talosMachineUpgradeLegacy, whose completion check used to compare only the
+			// image tag and so reported success without upgrading anything.
+			// TestAccTalosMachine_upgradeSchematic covers the same change on v1.13+, which
+			// takes the LifecycleService path instead.
+			//
+			// Asserted against the node rather than state: when the upgrade is skipped
+			// Terraform still records the new image, so an attribute check (and the
+			// PlanOnly step below) passes either way.
+			{
+				Config: testAccTalosMachineConfig(rName, schematicImage, baseVersion, baseVersion),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("talos_machine.this", "image",
+						fmt.Sprintf("%s:%s", schematicImage, baseVersion)),
+					checkNodeSchematic("talos_machine.this", schematicID),
+				),
+			},
+			// Step 3: upgrade to v1.13.0, cluster still healthy afterwards
 			{
 				Config: testAccTalosMachineConfig(rName, baseImage, upgradeVersion, baseVersion),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -382,7 +408,7 @@ func TestAccTalosMachine_upgrade(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.talos_cluster_health.this", "id"),
 				),
 			},
-			// Step 3: idempotency after upgrade
+			// Step 4: idempotency after upgrade
 			{
 				Config:   testAccTalosMachineConfig(rName, baseImage, upgradeVersion, baseVersion),
 				PlanOnly: true,
@@ -1897,5 +1923,85 @@ func TestDefaultTimeoutsSufficientForWorstCase(t *testing.T) {
 
 	if defaultUpdate < worstCaseUpdate {
 		t.Errorf("Update default %v < worst-case %v: legacy upgrade will time out", defaultUpdate, worstCaseUpdate)
+	}
+}
+
+// checkNodeSchematic asserts the Image Factory schematic the node actually booted, read
+// from ExtensionStatus the same way `talosctl get extensions` reports it.
+//
+// State says nothing about whether the installer ran: a skipped upgrade still leaves the
+// new image recorded, so only the node can distinguish a real upgrade from a silent no-op.
+func checkNodeSchematic(resourceName, wantSchematicID string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		machine, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+
+		secrets, ok := s.RootModule().Resources["talos_machine_secrets.this"]
+		if !ok {
+			return fmt.Errorf("talos_machine_secrets.this not found in state")
+		}
+
+		node := machine.Primary.Attributes["node"]
+		if node == "" {
+			return fmt.Errorf("%s has no node attribute", resourceName)
+		}
+
+		attrs := secrets.Primary.Attributes
+
+		ca, crt, key := attrs["client_configuration.ca_certificate"],
+			attrs["client_configuration.client_certificate"],
+			attrs["client_configuration.client_key"]
+		if ca == "" || crt == "" || key == "" {
+			return fmt.Errorf("talos_machine_secrets.this is missing client_configuration in state")
+		}
+
+		talosConfig := &clientconfig.Config{
+			Context: "acc",
+			Contexts: map[string]*clientconfig.Context{
+				"acc": {CA: ca, Crt: crt, Key: key},
+			},
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		c, err := client.New(ctx, client.WithConfig(talosConfig), client.WithEndpoints(node))
+		if err != nil {
+			return fmt.Errorf("building talos client for %s: %w", node, err)
+		}
+
+		defer c.Close() //nolint:errcheck
+
+		items, err := safe.StateListAll[*runtimeres.ExtensionStatus](client.WithNode(ctx, node), c.COSI)
+		if err != nil {
+			return fmt.Errorf("listing extensions on %s: %w", node, err)
+		}
+
+		var got string
+
+		for item := range items.All() {
+			// Image Factory reports the schematic as a pseudo-extension whose version is
+			// the schematic ID.
+			if item.TypedSpec().Metadata.Name == "schematic" {
+				got = item.TypedSpec().Metadata.Version
+
+				break
+			}
+		}
+
+		if got == "" {
+			return fmt.Errorf("node %s reports no schematic extension; it is not running a factory image", node)
+		}
+
+		if got != wantSchematicID {
+			return fmt.Errorf(
+				"node %s is running schematic %s, want %s — the image change never reached the node (issue #377)",
+				node, got, wantSchematicID,
+			)
+		}
+
+		return nil
 	}
 }

--- a/pkg/talos/talos_machine_resource_test.go
+++ b/pkg/talos/talos_machine_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/safe"
 	frameworkpath "github.com/hashicorp/terraform-plugin-framework/path"
 	frameworkresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -23,9 +24,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/siderolabs/talos/pkg/images"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/gendata"
+	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 	"golang.org/x/mod/semver"
 
 	"github.com/siderolabs/terraform-provider-talos/pkg/talos"
@@ -340,6 +345,9 @@ func TestAccTalosMachine_upgrade(t *testing.T) {
 	const (
 		baseVersion    = "v1.12.7"
 		upgradeVersion = "v1.13.0"
+		// Same version as baseVersion, different schematic — see step 2.
+		schematicImage = "factory.talos.dev/metal-installer/c9078f9419961640c712a8bf2bb9174933dfcf1da383fd8ea2b7dc21493f8bac"
+		schematicID    = "c9078f9419961640c712a8bf2bb9174933dfcf1da383fd8ea2b7dc21493f8bac"
 	)
 
 	baseImage := images.InstallerImageRepository("metal")
@@ -365,7 +373,25 @@ func TestAccTalosMachine_upgrade(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.talos_cluster_health.this", "id"),
 				),
 			},
-			// Step 2: upgrade to v1.13.0, cluster still healthy afterwards
+			// Step 2: change only the schematic, staying on baseVersion (issue #377).
+			// The node is pre-1.13 here, so talosMachineUpgrade falls back to
+			// talosMachineUpgradeLegacy, whose completion check used to compare only the
+			// image tag and so reported success without upgrading anything.
+			// TestAccTalosMachine_upgradeSchematic covers the same change on v1.13+, which
+			// takes the LifecycleService path instead.
+			//
+			// Asserted against the node rather than state: when the upgrade is skipped
+			// Terraform still records the new image, so an attribute check (and the
+			// PlanOnly step below) passes either way.
+			{
+				Config: testAccTalosMachineConfig(rName, schematicImage, baseVersion, baseVersion),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("talos_machine.this", "image",
+						fmt.Sprintf("%s:%s", schematicImage, baseVersion)),
+					checkNodeSchematic("talos_machine.this", schematicID),
+				),
+			},
+			// Step 3: upgrade to v1.13.0, cluster still healthy afterwards
 			{
 				Config: testAccTalosMachineConfig(rName, baseImage, upgradeVersion, baseVersion),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -374,7 +400,7 @@ func TestAccTalosMachine_upgrade(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.talos_cluster_health.this", "id"),
 				),
 			},
-			// Step 3: idempotency after upgrade
+			// Step 4: idempotency after upgrade
 			{
 				Config:   testAccTalosMachineConfig(rName, baseImage, upgradeVersion, baseVersion),
 				PlanOnly: true,
@@ -1915,5 +1941,85 @@ func TestDefaultTimeoutsSufficientForWorstCase(t *testing.T) {
 
 	if defaultUpdate < worstCaseUpdate {
 		t.Errorf("Update default %v < worst-case %v: legacy upgrade will time out", defaultUpdate, worstCaseUpdate)
+	}
+}
+
+// checkNodeSchematic asserts the Image Factory schematic the node actually booted, read
+// from ExtensionStatus the same way `talosctl get extensions` reports it.
+//
+// State says nothing about whether the installer ran: a skipped upgrade still leaves the
+// new image recorded, so only the node can distinguish a real upgrade from a silent no-op.
+func checkNodeSchematic(resourceName, wantSchematicID string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		machine, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+
+		secrets, ok := s.RootModule().Resources["talos_machine_secrets.this"]
+		if !ok {
+			return fmt.Errorf("talos_machine_secrets.this not found in state")
+		}
+
+		node := machine.Primary.Attributes["node"]
+		if node == "" {
+			return fmt.Errorf("%s has no node attribute", resourceName)
+		}
+
+		attrs := secrets.Primary.Attributes
+
+		ca, crt, key := attrs["client_configuration.ca_certificate"],
+			attrs["client_configuration.client_certificate"],
+			attrs["client_configuration.client_key"]
+		if ca == "" || crt == "" || key == "" {
+			return fmt.Errorf("talos_machine_secrets.this is missing client_configuration in state")
+		}
+
+		talosConfig := &clientconfig.Config{
+			Context: "acc",
+			Contexts: map[string]*clientconfig.Context{
+				"acc": {CA: ca, Crt: crt, Key: key},
+			},
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		c, err := client.New(ctx, client.WithConfig(talosConfig), client.WithEndpoints(node))
+		if err != nil {
+			return fmt.Errorf("building talos client for %s: %w", node, err)
+		}
+
+		defer c.Close() //nolint:errcheck
+
+		items, err := safe.StateListAll[*runtimeres.ExtensionStatus](client.WithNode(ctx, node), c.COSI)
+		if err != nil {
+			return fmt.Errorf("listing extensions on %s: %w", node, err)
+		}
+
+		var got string
+
+		for item := range items.All() {
+			// Image Factory reports the schematic as a pseudo-extension whose version is
+			// the schematic ID.
+			if item.TypedSpec().Metadata.Name == "schematic" {
+				got = item.TypedSpec().Metadata.Version
+
+				break
+			}
+		}
+
+		if got == "" {
+			return fmt.Errorf("node %s reports no schematic extension; it is not running a factory image", node)
+		}
+
+		if got != wantSchematicID {
+			return fmt.Errorf(
+				"node %s is running schematic %s, want %s — the image change never reached the node (issue #377)",
+				node, got, wantSchematicID,
+			)
+		}
+
+		return nil
 	}
 }


### PR DESCRIPTION
Fixes #377.

On a node predating LifecycleService, changing only the schematic left the node untouched while Terraform reported success and recorded the new image — the reporter's apply finished in `0s` and `talosctl get extensions` still showed the old schematic.

`talosMachineUpgradeLegacy` decided the upgrade was complete with:

```go
running := replaceImageTag(state.Image.ValueString(), version.Tag)
if running == state.Image.ValueString() { return nil }
```

`replaceImageTag` rebuilds the "running" image from the desired one, keeping its repository and substituting only the tag, so the two can only differ by tag. A new Image Factory schematic at the same Talos version compares equal on the **first** poll, so the function returns before the upgrade has done anything.

b812b76 removed this same tag-only comparison from `Update`, but the legacy path kept its own copy in the completion check. Nothing covered it: `TestAccTalosMachine_upgradeSchematic` pins `v1.13.0` and therefore always takes the LifecycleService path, so only nodes below 1.13 are affected — the reporter is on Talos v1.12.2.

## Fix
An upgrade always reboots, so use a changed boot ID as the completion signal — the same one `action.BootIDChangedPostCheckFn` uses for the reboot and v1.13+ paths. A version comparison cannot work here in principle, since the image can change without the version changing. A node that cannot report its boot ID falls back to waiting for the upgrade RPC to return.

## Test
Rather than add a cluster, this extends `TestAccTalosMachine_upgrade`, which already boots a pre-1.13 node: a new step changes only the schematic before the existing version upgrade, reusing that cluster. The step asserts the schematic the node actually booted, read from `ExtensionStatus` — a skipped upgrade still leaves the new image in state, so an attribute check and the following `PlanOnly` step pass either way. That is why the existing schematic test would not have caught this.

Verified locally against the extended test:

| | |
| --- | --- |
| without the fix | FAIL at step 2/4 — `node is running schematic 376567…, want c9078f94…` |
| with the fix | PASS (667s, vs 686s for the previous 3-step version — the added step reuses the cluster and costs no measurable CI time) |
| `TestAccTalosMachine_upgradeSchematic` (v1.13+ path, untouched) | PASS (616s) |