### PR TITLE
fix(talos_cluster): reject non-IP node addresses at plan time

### DIFF
--- a/docs/data-sources/cluster_health.md
+++ b/docs/data-sources/cluster_health.md
@@ -18,14 +18,14 @@ Waits for the Talos cluster to be healthy. Can be used as a dependency before ru
 ### Required
 
 - `client_configuration` (Attributes) The client configuration data (see [below for nested schema](#nestedatt--client_configuration))
-- `control_plane_nodes` (List of String) List of control plane nodes to check for health.
+- `control_plane_nodes` (List of String) List of control plane node IPs to check for health. Must be IPs: the health checks compare these against the addresses Kubernetes reports for each node.
 - `endpoints` (List of String) endpoints to use for the health check client. Use at least one control plane endpoint.
 
 ### Optional
 
 - `skip_kubernetes_checks` (Boolean) Skip Kubernetes component checks, this is useful to check if the nodes has finished booting up and kubelet is running. Default is false.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
-- `worker_nodes` (List of String) List of worker nodes to check for health.
+- `worker_nodes` (List of String) List of worker node IPs to check for health. Must be IPs: the health checks compare these against the addresses Kubernetes reports for each node.
 
 ### Read-Only
 

--- a/docs/ephemeral-resources/cluster_health.md
+++ b/docs/ephemeral-resources/cluster_health.md
@@ -18,14 +18,14 @@ Checks the health of a Talos cluster. This is an ephemeral resource that does no
 ### Required
 
 - `client_configuration` (Attributes) The client configuration data (see [below for nested schema](#nestedatt--client_configuration))
-- `control_plane_nodes` (List of String) List of control plane nodes to check for health.
+- `control_plane_nodes` (List of String) List of control plane node IPs to check for health. Must be IPs: the health checks compare these against the addresses Kubernetes reports for each node.
 - `endpoints` (List of String) endpoints to use for the health check client. Use at least one control plane endpoint.
 
 ### Optional
 
 - `skip_kubernetes_checks` (Boolean) Skip Kubernetes component checks, this is useful to check if the nodes has finished booting up and kubelet is running. Default is false.
 - `timeout` (String) Timeout for the health check. Defaults to 10m. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'.
-- `worker_nodes` (List of String) List of worker nodes to check for health.
+- `worker_nodes` (List of String) List of worker node IPs to check for health. Must be IPs: the health checks compare these against the addresses Kubernetes reports for each node.
 
 <a id="nestedatt--client_configuration"></a>
 ### Nested Schema for `client_configuration`

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -65,7 +65,7 @@ The `kubernetes_version` argument in `talos_machine_configuration` controls the 
 ### Required
 
 - `kubernetes_version` (String) Desired Kubernetes version (e.g. `v1.32.0`). This is the canonical driver for Kubernetes upgrades: changing it runs Talos's `upgrade-k8s` procedure, which sequentially upgrades kube-apiserver, kube-controller-manager, kube-scheduler, kube-proxy, and kubelet on each node with health gating. Set `ignore_kubernetes_upgrade_drift = true` on `talos_machine` so that image tag changes owned by `upgrade-k8s` are excluded from drift detection and `talos_cluster` fully owns the upgrade sequencing.
-- `node` (String) The IP address or hostname of the control plane node to bootstrap etcd on.
+- `node` (String) The IP address of the control plane node to bootstrap etcd on. Must be an IP: it defaults into `control_plane_nodes`, which the health checks compare against the addresses Kubernetes reports. Use `endpoint` to connect through a hostname.
 
 ### Optional
 

--- a/pkg/talos/ip_address_validator_test.go
+++ b/pkg/talos/ip_address_validator_test.go
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos //nolint:testpackage // exercises the unexported ipAddressValidator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestIPAddressValidator covers the node/control_plane_nodes constraint from issue #382:
+// a hostname used to reach cluster.IPsToNodeInfos and fail mid-apply with a bare
+// ParseAddr error, so this must be rejected at plan time instead.
+func TestIPAddressValidator(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		value   types.String
+		wantErr bool
+	}{
+		{"IPv4", types.StringValue("192.168.1.10"), false},
+		{"IPv6", types.StringValue("2001:db8::1"), false},
+		{"hostname", types.StringValue("host.example.com"), true},
+		{"bare hostname", types.StringValue("node1"), true},
+		{"URL", types.StringValue("https://192.168.1.10"), true},
+		{"IP with port", types.StringValue("192.168.1.10:50000"), true},
+		{"empty", types.StringValue(""), true},
+		// null/unknown are the caller's business, not the validator's
+		{"null", types.StringNull(), false},
+		{"unknown", types.StringUnknown(), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &validator.StringResponse{}
+			ipAddressValid().ValidateString(
+				context.Background(),
+				validator.StringRequest{
+					Path:        path.Root("node"),
+					ConfigValue: tc.value,
+				},
+				resp,
+			)
+
+			if got := resp.Diagnostics.HasError(); got != tc.wantErr {
+				t.Fatalf("HasError() = %v, want %v (diags: %v)", got, tc.wantErr, resp.Diagnostics)
+			}
+
+			if tc.wantErr {
+				// The bare ParseAddr message is what made #382 hard to act on, so the
+				// diagnostic must say what is wrong and where.
+				detail := resp.Diagnostics.Errors()[0].Detail()
+				if !strings.Contains(detail, "not an IP address") {
+					t.Errorf("detail does not explain the problem: %q", detail)
+				}
+
+				if !strings.Contains(detail, "endpoint") {
+					t.Errorf("detail does not point at the hostname-friendly alternative: %q", detail)
+				}
+			}
+		})
+	}
+}
+
+// TestNewClusterNodesRejectsHostname covers the apply-time half of issue #382. Attribute
+// validators only fire when the value is known at plan time, and node addresses usually
+// come from another resource, so this path has to give a usable error of its own rather
+// than a bare ParseAddr failure.
+func TestNewClusterNodesRejectsHostname(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		wantIn       string
+		controlPlane []string
+		workers      []string
+	}{
+		{"control plane hostname", "control plane nodes must be IP addresses", []string{"host.example.com"}, nil},
+		{"worker hostname", "worker nodes must be IP addresses", []string{"10.0.0.1"}, []string{"worker.example.com"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := newClusterNodes(tc.controlPlane, tc.workers)
+			if err == nil {
+				t.Fatal("expected an error for a hostname, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tc.wantIn) {
+				t.Errorf("error does not name the field or explain the rule: %v", err)
+			}
+
+			// the underlying cause should still be visible
+			if !strings.Contains(err.Error(), "ParseAddr") {
+				t.Errorf("error loses the underlying cause: %v", err)
+			}
+		})
+	}
+}
+
+// TestNewClusterNodesAcceptsIPs guards against the wrapping above rejecting valid input.
+func TestNewClusterNodesAcceptsIPs(t *testing.T) {
+	t.Parallel()
+
+	nodes, err := newClusterNodes([]string{"10.0.0.1", "2001:db8::1"}, []string{"10.0.0.2"})
+	if err != nil {
+		t.Fatalf("valid IPs rejected: %v", err)
+	}
+
+	if got := len(nodes.Nodes()); got != 3 {
+		t.Errorf("got %d nodes, want 3", got)
+	}
+}

--- a/pkg/talos/talos_cluster_health_data_source.go
+++ b/pkg/talos/talos_cluster_health_data_source.go
@@ -12,8 +12,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/siderolabs/talos/pkg/cluster"
@@ -43,14 +45,20 @@ type clusterNodes struct {
 }
 
 func newClusterNodes(controlPlaneNodes, workerNodes []string) (*clusterNodes, error) {
+	// The attribute validators catch non-IPs at plan time, but only when the value is
+	// known then. Node addresses usually come from another resource and are unknown until
+	// apply, so the same mistake has to produce a usable error here too rather than a bare
+	// ParseAddr failure. See issue #382.
 	controlPlaneNodeInfos, err := cluster.IPsToNodeInfos(controlPlaneNodes)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("control plane nodes must be IP addresses (health checks compare them "+
+			"against the addresses Kubernetes reports for each node): %w", err)
 	}
 
 	workerNodeInfos, err := cluster.IPsToNodeInfos(workerNodes)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("worker nodes must be IP addresses (health checks compare them "+
+			"against the addresses Kubernetes reports for each node): %w", err)
 	}
 
 	nodesByType := make(map[machine.Type][]cluster.NodeInfo)
@@ -120,12 +128,18 @@ func (d *talosClusterHealthDataSource) Schema(ctx context.Context, _ datasource.
 			"control_plane_nodes": schema.ListAttribute{
 				Required:    true,
 				ElementType: types.StringType,
-				Description: "List of control plane nodes to check for health.",
+				Description: "List of control plane node IPs to check for health. Must be IPs: the health checks compare these against the addresses Kubernetes reports for each node.",
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(ipAddressValid()),
+				},
 			},
 			"worker_nodes": schema.ListAttribute{
 				Optional:    true,
 				ElementType: types.StringType,
-				Description: "List of worker nodes to check for health.",
+				Description: "List of worker node IPs to check for health. Must be IPs: the health checks compare these against the addresses Kubernetes reports for each node.",
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(ipAddressValid()),
+				},
 			},
 			"skip_kubernetes_checks": schema.BoolAttribute{
 				Optional:    true,

--- a/pkg/talos/talos_cluster_health_ephemeral_resource.go
+++ b/pkg/talos/talos_cluster_health_ephemeral_resource.go
@@ -10,8 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/siderolabs/talos/pkg/cluster"
 	"github.com/siderolabs/talos/pkg/cluster/check"
@@ -75,12 +77,18 @@ func (r *talosClusterHealthEphemeralResource) Schema(_ context.Context, _ epheme
 			"control_plane_nodes": schema.ListAttribute{
 				Required:    true,
 				ElementType: types.StringType,
-				Description: "List of control plane nodes to check for health.",
+				Description: "List of control plane node IPs to check for health. Must be IPs: the health checks compare these against the addresses Kubernetes reports for each node.",
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(ipAddressValid()),
+				},
 			},
 			"worker_nodes": schema.ListAttribute{
 				Optional:    true,
 				ElementType: types.StringType,
-				Description: "List of worker nodes to check for health.",
+				Description: "List of worker node IPs to check for health. Must be IPs: the health checks compare these against the addresses Kubernetes reports for each node.",
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(ipAddressValid()),
+				},
 			},
 			"skip_kubernetes_checks": schema.BoolAttribute{
 				Optional:    true,

--- a/pkg/talos/talos_cluster_node_ip_test.go
+++ b/pkg/talos/talos_cluster_node_ip_test.go
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccTalosClusterNodeMustBeIP drives the real provider schema to prove the validator
+// is wired up, not merely correct in isolation: a hostname must fail during plan, before
+// anything contacts a node. Reproduces the config from issue #382.
+//
+// IsUnitTest: schema validation is client-side, so no cluster is involved.
+func TestAccTalosClusterNodeMustBeIP(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config string
+	}{
+		{
+			name: "node",
+			config: `
+resource "talos_cluster" "this" {
+  node               = "host.example.com"
+  kubernetes_version = "v1.35.3"
+  client_configuration = {
+    ca_certificate     = "Zm9v"
+    client_certificate = "YmFy"
+    client_key         = "YmF6"
+  }
+}
+`,
+		},
+		{
+			name: "control_plane_nodes",
+			config: `
+resource "talos_cluster" "this" {
+  node                = "10.0.0.1"
+  control_plane_nodes = ["10.0.0.1", "cp2.example.com"]
+  kubernetes_version  = "v1.35.3"
+  client_configuration = {
+    ca_certificate     = "Zm9v"
+    client_certificate = "YmFy"
+    client_key         = "YmF6"
+  }
+}
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resource.UnitTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config:      tc.config,
+						ExpectError: regexp.MustCompile(`is not an IP address`),
+					},
+				},
+			})
+		})
+	}
+}

--- a/pkg/talos/talos_cluster_resource.go
+++ b/pkg/talos/talos_cluster_resource.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -20,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -77,14 +79,22 @@ func (r *talosClusterResource) Schema(ctx context.Context, _ resource.SchemaRequ
 				},
 			},
 			"node": schema.StringAttribute{
-				Required:    true,
-				Description: "The IP address or hostname of the control plane node to bootstrap etcd on.",
+				Required: true,
+				Description: "The IP address of the control plane node to bootstrap etcd on. Must be an IP: it defaults into " +
+					"`control_plane_nodes`, which the health checks compare against the addresses Kubernetes reports. " +
+					"Use `endpoint` to connect through a hostname.",
+				Validators: []validator.String{
+					ipAddressValid(),
+				},
 			},
 			"control_plane_nodes": schema.ListAttribute{
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "List of all control plane node IPs used for etcd health checks. Defaults to [node]. Required for HA clusters where all control plane IPs must be listed.",
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(ipAddressValid()),
+				},
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.UseStateForUnknown(),
 				},

--- a/pkg/talos/util.go
+++ b/pkg/talos/util.go
@@ -17,6 +17,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net/netip"
 	"net/url"
 	"strings"
 	"time"
@@ -756,4 +757,46 @@ func talosClientTFConfigToTalosClientConfig(clusterName, ca, cert, key string) (
 	)
 
 	return talosConfig, nil
+}
+
+// ipAddressValidator rejects anything that is not an IP address.
+//
+// The cluster health checks match nodes against the addresses Kubernetes reports for them
+// (cluster.NodesMatch over Node.Status.Addresses), so node lists have to be IPs — a
+// hostname cannot be compared, and resolving one could yield a VIP or load balancer
+// address that parses but never matches. talosctl has the same restriction on its
+// equivalent flags. See issue #382.
+type ipAddressValidator struct{}
+
+func ipAddressValid() ipAddressValidator {
+	return ipAddressValidator{}
+}
+
+func (v ipAddressValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := req.ConfigValue.ValueString()
+
+	if _, err := netip.ParseAddr(value); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid IP address",
+			fmt.Sprintf(
+				"%q is not an IP address. Cluster health checks compare nodes against the addresses "+
+					"Kubernetes reports for them, so this has to be the node's IP rather than a hostname. "+
+					"Use `endpoint`/`endpoints` if you need to reach the cluster through a hostname.",
+				value,
+			),
+		)
+	}
+}
+
+func (v ipAddressValidator) Description(_ context.Context) string {
+	return "Validates that the value is an IP address"
+}
+
+func (v ipAddressValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
 }


### PR DESCRIPTION
Fixes #382.

`talos_cluster.node` is documented as taking "the IP address or hostname", but a hostname fails partway through the apply with a bare `ParseAddr("host.example.com"): unexpected character`.

`node` defaults into `control_plane_nodes`, which the health check hands to `cluster.IPsToNodeInfos` → `netip.ParseAddr`. The `talos_cluster_health` data source and ephemeral resource reach the same path.

Resolving the hostname would not be a safe fix: `K8sAllNodesReportedAssertion` builds the actual node set from Kubernetes `Node.Status.Addresses` and compares with `cluster.NodesMatch`, so the value has to be an address Kubernetes reports for that node. A name pointing at a VIP would parse and then fail the match later. `talosctl` restricts the equivalent `--control-plane-nodes` flags the same way.

- validators on `talos_cluster.node` / `control_plane_nodes`, and on `control_plane_nodes` / `worker_nodes` for the health data source and ephemeral resource. `endpoint`/`endpoints` are untouched — they are only dialled, so hostnames stay valid there
- corrected descriptions
- `newClusterNodes` now names the field in its error, for the case where the value is unknown at plan time and the validators cannot fire

Not a narrowing: `node` was already required to be a member of `control_plane_nodes`, already documented as IPs. The validator calls the same `netip.ParseAddr` as the code downstream, so it cannot reject anything that would have succeeded.

`TestAccTalosClusterNodeMustBeIP` drives the real schema and asserts plan fails for a hostname in both fields.