### PR TITLE
fix(talos_machine): reconcile schematic on create

### DIFF
--- a/pkg/talos/export_test.go
+++ b/pkg/talos/export_test.go
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+var (
+	TalosMachineCheckBootReady        = talosMachineCheckBootReady
+	TalosMachineWaitForBoot           = talosMachineWaitForBoot
+	TalosMachineRebootBeforeBootstrap = talosMachineRebootBeforeBootstrap
+)

--- a/pkg/talos/talos_machine_boot_readiness_internal_test.go
+++ b/pkg/talos/talos_machine_boot_readiness_internal_test.go
@@ -1,0 +1,284 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
+	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/siderolabs/terraform-provider-talos/pkg/talos"
+)
+
+type bootVersionClient struct {
+	machineapi.MachineServiceClient
+	calls *int
+	err   error
+}
+
+func (c bootVersionClient) Version(context.Context, *emptypb.Empty, ...grpc.CallOption) (*machineapi.VersionResponse, error) {
+	if c.calls != nil {
+		*c.calls++
+	}
+
+	if c.err != nil {
+		return nil, c.err
+	}
+
+	return &machineapi.VersionResponse{}, nil
+}
+
+func bootTestClient(t *testing.T, stage runtimeres.MachineStage, running, healthy bool) *client.Client {
+	t.Helper()
+
+	st := state.WrapCore(inmem.NewState(runtimeres.NamespaceName))
+	machine := runtimeres.NewMachineStatus()
+	machine.TypedSpec().Stage = stage
+	// Kubernetes is not bootstrapped yet: overall Ready deliberately remains false.
+	require.NoError(t, st.Create(t.Context(), machine))
+
+	cri := v1alpha1.NewService("cri")
+	cri.TypedSpec().Running = running
+	cri.TypedSpec().Healthy = healthy
+	require.NoError(t, st.Create(t.Context(), cri))
+
+	return &client.Client{COSI: st, MachineClient: bootVersionClient{}}
+}
+
+func TestTalosMachineBootReadiness(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		stage   runtimeres.MachineStage
+		running bool
+		healthy bool
+		ready   bool
+	}{
+		{"maintenance API responds before installation", runtimeres.MachineStageMaintenance, false, false, false},
+		{"installation in progress", runtimeres.MachineStageInstalling, false, false, false},
+		{"reboot pending with services still alive", runtimeres.MachineStageRebooting, true, true, false},
+		{"boot API responds before CRI starts", runtimeres.MachineStageBooting, false, false, false},
+		{"boot waits for etcd but CRI is ready", runtimeres.MachineStageBooting, true, true, true},
+		{"CRI not started", runtimeres.MachineStageRunning, false, false, false},
+		{"CRI not healthy", runtimeres.MachineStageRunning, true, false, false},
+		{"ready to install before etcd bootstrap", runtimeres.MachineStageRunning, true, true, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := bootTestClient(t, tt.stage, tt.running, tt.healthy)
+
+			err := talos.TalosMachineCheckBootReady(t.Context(), c)
+			if tt.ready {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err, "a responding Version API does not mean the node can pull an installer")
+			}
+		})
+	}
+}
+
+func TestTalosMachineBootWaitSurvivesReboot(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	booting := bootTestClient(t, runtimeres.MachineStageBooting, false, false)
+	ready := bootTestClient(t, runtimeres.MachineStageRunning, true, true)
+	calls := 0
+	op := func(ctx context.Context, _, _ string, _ *clientconfig.Config, fn func(context.Context, *client.Client) error) error {
+		calls++
+		switch calls {
+		case 1:
+			return status.Error(codes.Unavailable, "connection refused during reboot")
+		case 2:
+			return fn(ctx, booting)
+		default:
+			return fn(ctx, ready)
+		}
+	}
+
+	require.NoError(t, talos.TalosMachineWaitForBoot(ctx, "endpoint", "node", nil, op))
+	require.Equal(t, 3, calls, "must wait past the first API response after reboot")
+}
+
+func TestTalosMachineBootReadinessWaitsForUnattendedInstall(t *testing.T) {
+	t.Parallel()
+
+	for _, phase := range []runtimeres.UnattendedInstallPhase{
+		runtimeres.UnattendedInstallPhasePending,
+		runtimeres.UnattendedInstallPhaseInstalling,
+		runtimeres.UnattendedInstallPhaseWaitingForReboot,
+		runtimeres.UnattendedInstallPhaseInstalled,
+	} {
+		t.Run(phase.String(), func(t *testing.T) {
+			t.Parallel()
+
+			c := bootTestClient(t, runtimeres.MachineStageBooting, true, true)
+			install := runtimeres.NewUnattendedInstallStatus()
+			install.TypedSpec().Phase = phase
+			require.NoError(t, c.COSI.Create(t.Context(), install))
+
+			err := talos.TalosMachineCheckBootReady(t.Context(), c)
+			if phase == runtimeres.UnattendedInstallPhaseInstalled {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err, "must not race an unfinished first install or its scheduled reboot")
+			}
+		})
+	}
+}
+
+type bootTestUnsupportedState struct {
+	state.State
+	err error
+}
+
+func (s bootTestUnsupportedState) Get(ctx context.Context, ptr resource.Pointer, opts ...state.GetOption) (resource.Resource, error) {
+	if ptr.Type() == runtimeres.UnattendedInstallStatusType {
+		return nil, s.err
+	}
+
+	return s.State.Get(ctx, ptr, opts...)
+}
+
+type bootTestDeniedState struct {
+	state.State
+	err error
+}
+
+func (s bootTestDeniedState) Get(context.Context, resource.Pointer, ...state.GetOption) (resource.Resource, error) {
+	return nil, s.err
+}
+
+func TestTalosMachineBootReadinessOlderTalos(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		err   error
+		name  string
+		ready bool
+	}{
+		{
+			name:  "old server has no unattended install resource type",
+			err:   status.Errorf(codes.PermissionDenied, "resource type %q is not supported", runtimeres.UnattendedInstallStatusType),
+			ready: true,
+		},
+		{
+			name: "actual permission denial must not be ignored",
+			err:  status.Error(codes.PermissionDenied, "not authorized to read this resource"),
+		},
+		{
+			name: "other server errors must not be ignored",
+			err:  status.Errorf(codes.Unknown, "resource type %q is not supported", runtimeres.UnattendedInstallStatusType),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := bootTestClient(t, runtimeres.MachineStageBooting, true, true)
+			c.COSI = bootTestUnsupportedState{State: c.COSI, err: tt.err}
+
+			err := talos.TalosMachineCheckBootReady(t.Context(), c)
+			if tt.ready {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tt.err)
+			}
+		})
+	}
+}
+
+func TestTalosMachineBootWaitRejectsInvalidCredentials(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	want := status.Error(codes.PermissionDenied, "not authorized")
+	calls := 0
+	op := func(context.Context, string, string, *clientconfig.Config, func(context.Context, *client.Client) error) error {
+		calls++
+
+		return want
+	}
+
+	require.ErrorIs(t, talos.TalosMachineWaitForBoot(ctx, "endpoint", "node", nil, op), want)
+	require.Equal(t, 1, calls)
+}
+
+func TestTalosMachineBootWaitFallsBackForRestrictedRole(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	c := bootTestClient(t, runtimeres.MachineStageBooting, true, true)
+	c.COSI = bootTestDeniedState{
+		State: c.COSI,
+		err:   status.Error(codes.PermissionDenied, "role cannot read runtime resources"),
+	}
+	calls := 0
+	op := func(ctx context.Context, _ string, _ string, _ *clientconfig.Config, fn func(context.Context, *client.Client) error) error {
+		calls++
+
+		return fn(ctx, c)
+	}
+
+	require.NoError(t, talos.TalosMachineWaitForBoot(ctx, "endpoint", "node", nil, op))
+	require.Equal(t, 1, calls, "should succeed without retrying")
+}
+
+func TestTalosMachineBootWaitDoesNotHideInvalidCredentials(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	versionCalls := 0
+	versionErr := status.Error(codes.Unauthenticated, "client credentials are invalid")
+	c := bootTestClient(t, runtimeres.MachineStageBooting, true, true)
+	c.COSI = bootTestDeniedState{
+		State: c.COSI,
+		err:   status.Error(codes.PermissionDenied, "role cannot read runtime resources"),
+	}
+	c.MachineClient = bootVersionClient{calls: &versionCalls, err: versionErr}
+	op := func(ctx context.Context, _ string, _ string, _ *clientconfig.Config, fn func(context.Context, *client.Client) error) error {
+		return fn(ctx, c)
+	}
+
+	require.ErrorIs(t, talos.TalosMachineWaitForBoot(ctx, "endpoint", "node", nil, op), versionErr)
+	require.Equal(t, 1, versionCalls, "fallback must verify API access")
+}
+
+func TestTalosMachineBootWaitHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	op := func(ctx context.Context, _, _ string, _ *clientconfig.Config, _ func(context.Context, *client.Client) error) error {
+		cancel()
+
+		return ctx.Err()
+	}
+
+	require.Error(t, talos.TalosMachineWaitForBoot(ctx, "endpoint", "node", nil, op))
+}

--- a/pkg/talos/talos_machine_reboot_internal_test.go
+++ b/pkg/talos/talos_machine_reboot_internal_test.go
@@ -1,0 +1,196 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos_test
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	commonapi "github.com/siderolabs/talos/pkg/machinery/api/common"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
+	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/terraform-provider-talos/pkg/talos"
+)
+
+type rebootTestStream struct {
+	grpc.ClientStream
+	bootID string
+	done   bool
+}
+
+func (s *rebootTestStream) Recv() (*commonapi.Data, error) {
+	if s.done {
+		return nil, io.EOF
+	}
+
+	s.done = true
+
+	return &commonapi.Data{Bytes: []byte(s.bootID)}, nil
+}
+
+func (*rebootTestStream) CloseSend() error { return nil }
+
+type rebootTestMachine struct {
+	machineapi.MachineServiceClient
+	read   func() (string, error)
+	reboot func(*machineapi.RebootRequest) error
+}
+
+func (m rebootTestMachine) Read(_ context.Context, req *machineapi.ReadRequest, _ ...grpc.CallOption) (machineapi.MachineService_ReadClient, error) {
+	if req.GetPath() != "/proc/sys/kernel/random/boot_id" {
+		return nil, status.Error(codes.InvalidArgument, "unexpected read path")
+	}
+
+	id, err := m.read()
+	if err != nil {
+		return nil, err
+	}
+
+	return &rebootTestStream{bootID: id}, nil
+}
+
+func (m rebootTestMachine) Reboot(_ context.Context, req *machineapi.RebootRequest, _ ...grpc.CallOption) (*machineapi.RebootResponse, error) {
+	return &machineapi.RebootResponse{Messages: []*machineapi.Reboot{{}}}, m.reboot(req)
+}
+
+func TestTalosMachineRebootBeforeBootstrap(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	reads, reboots := 0, 0
+	machine := rebootTestMachine{
+		read: func() (string, error) {
+			reads++
+			switch reads {
+			case 1, 2:
+				return "old-boot", nil
+			case 3:
+				return "", status.Error(codes.Unavailable, "rebooting")
+			default:
+				return "new-boot", nil
+			}
+		},
+		reboot: func(req *machineapi.RebootRequest) error {
+			reboots++
+
+			require.Equal(t, 1, reads, "record boot ID before requesting reboot")
+			require.Equal(t, machineapi.RebootRequest_POWERCYCLE, req.GetMode())
+
+			return nil
+		},
+	}
+	booting := bootTestClient(t, runtimeres.MachineStageBooting, false, false)
+	ready := bootTestClient(t, runtimeres.MachineStageBooting, true, true)
+	booting.MachineClient, ready.MachineClient = machine, machine
+	op := func(ctx context.Context, _, _ string, _ *clientconfig.Config, fn func(context.Context, *client.Client) error) error {
+		c := booting
+		if reads < 3 || reads >= 5 {
+			c = ready
+		}
+
+		return fn(ctx, c)
+	}
+
+	// No Events RPC is implemented: a missed shutdown event must not block
+	// completion, and overall machine Ready is false until etcd is bootstrapped.
+	require.NoError(t, talos.TalosMachineRebootBeforeBootstrap(ctx, "endpoint", "node", nil, machineapi.RebootRequest_POWERCYCLE, op))
+	require.Equal(t, 5, reads, "wait for a different boot ID and healthy CRI")
+	require.Equal(t, 1, reboots, "never repeat the reboot RPC while polling")
+}
+
+func TestTalosMachineRebootBeforeBootstrapRejectsErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		rebootError error
+		name        string
+		bootID      string
+		wantReboots int
+	}{
+		{name: "missing initial boot ID"},
+		{name: "reboot rejected", bootID: "old-boot", rebootError: status.Error(codes.PermissionDenied, "denied"), wantReboots: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reads, reboots := 0, 0
+			c := &client.Client{MachineClient: rebootTestMachine{
+				read: func() (string, error) {
+					reads++
+
+					return tt.bootID, nil
+				},
+				reboot: func(*machineapi.RebootRequest) error {
+					reboots++
+
+					return tt.rebootError
+				},
+			}}
+			op := func(ctx context.Context, _, _ string, _ *clientconfig.Config, fn func(context.Context, *client.Client) error) error {
+				return fn(ctx, c)
+			}
+
+			require.Error(t, talos.TalosMachineRebootBeforeBootstrap(t.Context(), "endpoint", "node", nil, machineapi.RebootRequest_DEFAULT, op))
+			require.Equal(t, 1, reads)
+			require.Equal(t, tt.wantReboots, reboots)
+		})
+	}
+}
+
+func TestTalosMachineRebootBeforeBootstrapRestrictedRole(t *testing.T) {
+	t.Parallel()
+
+	for _, deniedBeforeReboot := range []bool{true, false} {
+		name := "after reboot"
+		if deniedBeforeReboot {
+			name = "before reboot"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+
+			reads, reboots, versionCalls := 0, 0, 0
+			c := bootTestClient(t, runtimeres.MachineStageBooting, true, true)
+			c.COSI = bootTestDeniedState{State: c.COSI, err: status.Error(codes.PermissionDenied, "restricted role")}
+			c.MachineClient = rebootTestMachine{
+				MachineServiceClient: bootVersionClient{calls: &versionCalls},
+				read: func() (string, error) {
+					reads++
+					if reads == 1 && !deniedBeforeReboot {
+						return "old-boot", nil
+					}
+
+					return "", status.Error(codes.PermissionDenied, "restricted role")
+				},
+				reboot: func(*machineapi.RebootRequest) error {
+					reboots++
+
+					return nil
+				},
+			}
+			op := func(ctx context.Context, _, _ string, _ *clientconfig.Config, fn func(context.Context, *client.Client) error) error {
+				return fn(ctx, c)
+			}
+
+			require.NoError(t, talos.TalosMachineRebootBeforeBootstrap(ctx, "endpoint", "node", nil, machineapi.RebootRequest_DEFAULT, op))
+			require.Equal(t, 1, reboots)
+			require.Equal(t, 1, versionCalls)
+		})
+	}
+}

--- a/pkg/talos/talos_machine_resource.go
+++ b/pkg/talos/talos_machine_resource.go
@@ -14,6 +14,7 @@ import (
 
 	cosiresource "github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
+	cosistate "github.com/cosi-project/runtime/pkg/state"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -36,6 +37,8 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	configresource "github.com/siderolabs/talos/pkg/machinery/resources/config"
+	runtimeres "github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	serviceres "github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
 	talosreporter "github.com/siderolabs/talos/pkg/reporter"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -47,7 +50,7 @@ import (
 // for talos_machine timeouts. Exported so tests can assert they cover the
 // worst-case internal retry budgets without duplicating magic numbers.
 const (
-	DefaultCreateTimeout = 25 * time.Minute // 10m apply + 10m wait-for-node + margin
+	DefaultCreateTimeout = 40 * time.Minute // 10m apply + 10m wait-for-node + 15m create reboot + margin
 	DefaultUpdateTimeout = 90 * time.Minute // above + 60m legacy upgrade poll + margin
 )
 
@@ -648,7 +651,7 @@ func (r *talosMachineResource) Update(ctx context.Context, req resource.UpdateRe
 	imageChanged := !plan.Image.IsNull() && !plan.Image.Equal(state.Image)
 
 	if imageChanged {
-		if err := talosMachineUpgrade(ctxDeadline, endpoint, plan.Node.ValueString(), talosConfig, &plan); err != nil {
+		if err := talosMachineUpgrade(ctxDeadline, endpoint, plan.Node.ValueString(), talosConfig, &plan, true); err != nil {
 			resp.Diagnostics.AddError("error upgrading Talos", err.Error())
 
 			return
@@ -752,7 +755,7 @@ func (r *talosMachineResource) Delete(ctx context.Context, req resource.DeleteRe
 }
 
 // talosMachineApplyConfig applies the machine configuration with retry and waits for
-// the node to be reachable afterwards (it reboots on first config apply).
+// CRI to be ready during normal boot (first apply can install and reboot).
 func talosMachineApplyConfig(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, cfgBytes []byte) error {
 	if err := retry.RetryContext(ctx, 10*time.Minute, func() *retry.RetryError {
 		if err := talosClientOp(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
@@ -775,23 +778,86 @@ func talosMachineApplyConfig(ctx context.Context, endpoint, node string, talosCo
 		return fmt.Errorf("applying configuration: %w", err)
 	}
 
-	// Poll until node is back up — it may have rebooted after first config apply.
-	return retry.RetryContext(ctx, 10*time.Minute, func() *retry.RetryError {
-		if err := talosClientOp(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
-			_, err := c.Version(nodeCtx)
+	// The API also responds during maintenance and early boot. Wait until the
+	// node is out of maintenance and CRI is ready before reading extensions or pulling an installer.
+	return talosMachineWaitForBoot(ctx, endpoint, node, talosConfig, talosClientOp)
+}
 
-			return err
-		}); err != nil {
-			return retry.RetryableError(err)
+func talosMachineWaitForBoot(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, op clientOpFunc) error {
+	return retry.RetryContext(ctx, 10*time.Minute, func() *retry.RetryError {
+		attemptCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		if err := op(attemptCtx, endpoint, node, talosConfig, talosMachineCheckBootReadyOrVersion); err != nil {
+			return talosMachineBootRetryError(err)
 		}
 
 		return nil
 	})
 }
 
+func talosMachineBootRetryError(err error) *retry.RetryError {
+	if code := status.Code(err); code == codes.PermissionDenied || code == codes.Unauthenticated || code == codes.InvalidArgument {
+		return retry.NonRetryableError(err)
+	}
+
+	return retry.RetryableError(err)
+}
+
+// Fall back to Version when the role cannot read runtime resources.
+func talosMachineCheckBootReadyOrVersion(ctx context.Context, c *client.Client) error {
+	err := talosMachineCheckBootReady(ctx, c)
+	if status.Code(err) != codes.PermissionDenied {
+		return err
+	}
+
+	_, err = c.Version(ctx)
+
+	return err
+}
+
+func talosMachineCheckBootReady(ctx context.Context, c *client.Client) error {
+	machine, err := safe.StateGet[*runtimeres.MachineStatus](ctx, c.COSI, runtimeres.NewMachineStatus().Metadata())
+	if err != nil {
+		return fmt.Errorf("reading machine boot status: %w", err)
+	}
+
+	if stage := machine.TypedSpec().Stage; stage != runtimeres.MachineStageBooting && stage != runtimeres.MachineStageRunning {
+		return fmt.Errorf("waiting for normal boot: stage is %s", stage)
+	}
+
+	// Talos 1.14 keeps this status at waiting-for-reboot until the first
+	// install's reboot has actually happened. Older Talos has no such resource.
+	install, err := safe.StateGet[*runtimeres.UnattendedInstallStatus](ctx, c.COSI, runtimeres.NewUnattendedInstallStatus().Metadata())
+	// Older COSI servers reject unknown types with this specific PermissionDenied
+	// response. Do not suppress actual authorization failures on supported types.
+	unsupported := status.Code(err) == codes.PermissionDenied &&
+		status.Convert(err).Message() == fmt.Sprintf("resource type %q is not supported", runtimeres.UnattendedInstallStatusType)
+	if err != nil && !cosistate.IsNotFoundError(err) && !unsupported {
+		return fmt.Errorf("reading unattended install status: %w", err)
+	}
+
+	if install != nil && install.TypedSpec().Phase != runtimeres.UnattendedInstallPhaseInstalled {
+		return fmt.Errorf("waiting for unattended install: phase is %s", install.TypedSpec().Phase)
+	}
+
+	cri, err := safe.StateGet[*serviceres.Service](ctx, c.COSI, serviceres.NewService("cri").Metadata())
+	if err != nil {
+		return fmt.Errorf("reading CRI service status: %w", err)
+	}
+
+	if spec := cri.TypedSpec(); !spec.Running || !spec.Healthy || spec.Unknown {
+		return fmt.Errorf("waiting for CRI containerd to be running and healthy")
+	}
+
+	// Neither the running stage nor overall Ready is required: finishing boot
+	// can wait for etcd, whose bootstrap depends on this resource completing.
+	return nil
+}
+
 // talosMachineUpgrade upgrades the Talos OS to the desired installer image
 // by performing: pull → install → drain → reboot → uncordon.
-func talosMachineUpgrade(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, state *talosMachineResourceModel) (retErr error) {
+func talosMachineUpgrade(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, state *talosMachineResourceModel, waitForKubernetes bool) (retErr error) {
 	rebootModeStr := strings.ToUpper(state.RebootMode.ValueString())
 
 	containerdInst := &commonapi.ContainerdInstance{
@@ -837,26 +903,104 @@ func talosMachineUpgrade(ctx context.Context, endpoint, node string, talosConfig
 		}
 	}()
 
-	if err := talosMachineReboot(ctx, endpoint, node, talosConfig, rebootModeStr); err != nil {
+	if err := talosMachineReboot(ctx, endpoint, node, talosConfig, rebootModeStr, waitForKubernetes); err != nil {
 		return fmt.Errorf("waiting for node after reboot: %w", err)
 	}
 
 	return nil
 }
 
-// talosMachineUpgradeIfNeeded checks the running Talos version and, if it differs from
-// the desired image, performs: pull → install → drain → reboot → uncordon.
+// talosMachineUpgradeIfNeeded checks the running Talos version and, for Image Factory
+// images, the active schematic. If either differs from the desired image, it performs:
+// pull → install → drain → reboot → uncordon.
 func talosMachineUpgradeIfNeeded(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, state *talosMachineResourceModel) (retErr error) {
 	runningImage, err := talosMachineRunningVersion(ctx, endpoint, node, talosConfig, state.Image.ValueString())
 	if err != nil {
 		return fmt.Errorf("reading running version: %w", err)
 	}
 
-	if runningImage == state.Image.ValueString() {
+	if runningImage != state.Image.ValueString() {
+		return talosMachineUpgrade(ctx, endpoint, node, talosConfig, state, false)
+	}
+
+	requestedSchematic, isImageFactoryImage := talosMachineImageFactorySchematic(state.Image.ValueString())
+	if !isImageFactoryImage {
 		return nil
 	}
 
-	return talosMachineUpgrade(ctx, endpoint, node, talosConfig, state)
+	runningSchematic, err := talosMachineRunningSchematic(ctx, endpoint, node, talosConfig)
+	if err != nil {
+		return fmt.Errorf("reading active Image Factory schematic: %w", err)
+	}
+
+	if runningSchematic == requestedSchematic {
+		return nil
+	}
+
+	return talosMachineUpgrade(ctx, endpoint, node, talosConfig, state, false)
+}
+
+// talosMachineImageFactorySchematic returns the schematic ID embedded in the standard
+// Image Factory installer repository layout:
+// <registry>/[<platform>-]installer[-secureboot]/<schematic>:<version>.
+func talosMachineImageFactorySchematic(imageRef string) (string, bool) {
+	if strings.Contains(imageRef, "@") {
+		return "", false
+	}
+
+	repository := imageRef
+	lastSlash := strings.LastIndex(repository, "/")
+
+	if tagStart := strings.LastIndex(repository, ":"); tagStart > lastSlash {
+		repository = repository[:tagStart]
+	}
+
+	parts := strings.Split(repository, "/")
+	if len(parts) < 2 {
+		return "", false
+	}
+
+	installerRepository := parts[len(parts)-2]
+	schematicID := parts[len(parts)-1]
+	isFactoryInstaller := installerRepository == "installer" ||
+		installerRepository == "installer-secureboot" ||
+		strings.HasSuffix(installerRepository, "-installer") ||
+		strings.HasSuffix(installerRepository, "-installer-secureboot")
+
+	if schematicID == "" || !isFactoryInstaller {
+		return "", false
+	}
+
+	return schematicID, true
+}
+
+// talosMachineRunningSchematic reads the Image Factory schematic reported by Talos as
+// an ExtensionStatus pseudo-extension. A vanilla image has no such status and returns
+// an empty ID, which intentionally differs from every requested Factory schematic.
+func talosMachineRunningSchematic(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config) (string, error) {
+	var schematicID string
+
+	err := talosClientOp(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
+		items, err := safe.StateListAll[*runtimeres.ExtensionStatus](nodeCtx, c.COSI)
+		if err != nil {
+			return err
+		}
+
+		for item := range items.All() {
+			if item.TypedSpec().Metadata.Name == "schematic" {
+				schematicID = item.TypedSpec().Metadata.Version
+
+				break
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return schematicID, nil
 }
 
 func talosMachineRunningVersion(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, desiredImage string) (string, error) {
@@ -1010,13 +1154,17 @@ func kubeclientFromRaw(kubeconfigBytes []byte) (kubernetes.Interface, error) {
 	return cs, nil
 }
 
-func talosMachineReboot(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, rebootModeStr string) error {
+func talosMachineReboot(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, rebootModeStr string, waitForKubernetes bool) error {
 	rebootModeVal, ok := machineapi.RebootRequest_Mode_value[rebootModeStr]
 	if !ok {
 		rebootModeVal = int32(machineapi.RebootRequest_DEFAULT)
 	}
 
 	rebootMode := machineapi.RebootRequest_Mode(rebootModeVal)
+
+	if !waitForKubernetes {
+		return talosMachineRebootBeforeBootstrap(ctx, endpoint, node, talosConfig, rebootMode, talosClientOp)
+	}
 
 	return action.NewTracker(
 		newTalosClientFactory(talosConfig, endpoint, []string{node}),
@@ -1036,6 +1184,51 @@ func talosMachineReboot(ctx context.Context, endpoint, node string, talosConfig 
 		action.WithPostCheck(action.BootIDChangedPostCheckFn),
 		action.WithTimeout(15*time.Minute),
 	).Run(ctx)
+}
+
+// Create can precede etcd bootstrap, so Kubernetes readiness cannot gate its
+// reboot. Poll boot ID and CRI directly: shutdown events can be lost on reconnect.
+// Restricted roles that cannot read boot ID fall back to checking API readiness.
+func talosMachineRebootBeforeBootstrap(ctx context.Context, endpoint, node string, talosConfig *clientconfig.Config, rebootMode machineapi.RebootRequest_Mode, op clientOpFunc) error {
+	preBootID, err := talosMachineBootID(ctx, endpoint, node, talosConfig, op)
+	if err != nil {
+		if status.Code(err) != codes.PermissionDenied {
+			return fmt.Errorf("reading boot ID before reboot: %w", err)
+		}
+
+		tflog.Warn(ctx, "could not read boot ID before reboot; falling back to API readiness", map[string]any{"error": err.Error()})
+	}
+
+	if err := op(ctx, endpoint, node, talosConfig, func(nodeCtx context.Context, c *client.Client) error {
+		return c.Reboot(nodeCtx, client.WithRebootMode(rebootMode))
+	}); err != nil {
+		return fmt.Errorf("requesting reboot: %w", err)
+	}
+
+	return retry.RetryContext(ctx, 15*time.Minute, func() *retry.RetryError {
+		attemptCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		if preBootID != "" {
+			bootID, err := talosMachineBootID(attemptCtx, endpoint, node, talosConfig, op)
+			switch {
+			case status.Code(err) == codes.PermissionDenied:
+				tflog.Warn(ctx, "could not read boot ID after reboot; falling back to API readiness", map[string]any{"error": err.Error()})
+
+				preBootID = ""
+			case err != nil:
+				return retry.RetryableError(err)
+			case bootID == preBootID:
+				return retry.RetryableError(errors.New("waiting for boot ID to change"))
+			}
+		}
+
+		if err := op(attemptCtx, endpoint, node, talosConfig, talosMachineCheckBootReadyOrVersion); err != nil {
+			return talosMachineBootRetryError(err)
+		}
+
+		return nil
+	})
 }
 
 // talosMachineBootID reads the node's boot ID, which the kernel regenerates on every boot.

--- a/pkg/talos/talos_machine_resource_internal_test.go
+++ b/pkg/talos/talos_machine_resource_internal_test.go
@@ -147,3 +147,63 @@ func TestTalosMachineReconcileRunningImage(t *testing.T) {
 		})
 	}
 }
+
+func TestTalosMachineImageFactorySchematic(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		imageRef  string
+		schematic string
+		ok        bool
+	}{
+		"bare installer": {
+			imageRef:  "factory.talos.dev/installer/abc123:v1.13.0",
+			schematic: "abc123",
+			ok:        true,
+		},
+		"bare secure boot installer": {
+			imageRef:  "factory.talos.dev/installer-secureboot/abc123:v1.13.0",
+			schematic: "abc123",
+			ok:        true,
+		},
+		"default factory": {
+			imageRef:  "factory.talos.dev/metal-installer/abc123:v1.13.0",
+			schematic: "abc123",
+			ok:        true,
+		},
+		"custom registry": {
+			imageRef:  "images.example.com/talos/openstack-installer/def456:v1.13.0",
+			schematic: "def456",
+			ok:        true,
+		},
+		"registry with port and secure boot": {
+			imageRef:  "images.example.com:5000/metal-installer-secureboot/789abc:v1.13.0",
+			schematic: "789abc",
+			ok:        true,
+		},
+		"standard installer": {
+			imageRef: "ghcr.io/siderolabs/installer:v1.13.0",
+		},
+		"factory artifact": {
+			imageRef: "factory.talos.dev/image/abc123/v1.13.0/metal-amd64.raw.xz",
+		},
+		"digest": {
+			imageRef: "factory.talos.dev/metal-installer/abc123@sha256:1234",
+		},
+		"empty schematic": {
+			imageRef: "factory.talos.dev/metal-installer/:v1.13.0",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			schematic, ok := talosMachineImageFactorySchematic(test.imageRef)
+			if schematic != test.schematic || ok != test.ok {
+				t.Fatalf("talosMachineImageFactorySchematic(%q) = (%q, %t), want (%q, %t)",
+					test.imageRef, schematic, ok, test.schematic, test.ok)
+			}
+		})
+	}
+}

--- a/pkg/talos/talos_machine_resource_test.go
+++ b/pkg/talos/talos_machine_resource_test.go
@@ -74,6 +74,63 @@ func TestAccTalosMachine_bootstrap(t *testing.T) {
 	})
 }
 
+// TestAccTalosMachine_bootstrapWithSchematic boots a vanilla ISO and leaves the
+// initial install image at its default. Only talos_machine.image requests the
+// non-default Factory schematic, exercising same-version reconciliation on Create.
+func TestAccTalosMachine_bootstrapWithSchematic(t *testing.T) {
+	const (
+		talosVersion = "v1.14.0"
+		factoryImage = "factory.talos.dev/metal-installer/${talos_image_factory_schematic.this.id}"
+	)
+
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	// Register the schematic with Factory before the node pulls its installer.
+	config := testAccTalosMachineConfigWithoutInstallImage(rName, factoryImage, talosVersion, talosVersion) + `
+resource "talos_image_factory_schematic" "this" {
+  schematic = yamlencode({
+    customization = {
+      extraKernelArgs = ["console=ttyS0"]
+    }
+  })
+}
+`
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"libvirt": {
+				Source:            "dmacvicar/libvirt",
+				VersionConstraint: "= 0.8.3",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					func(s *terraform.State) error {
+						schematic, ok := s.RootModule().Resources["talos_image_factory_schematic.this"]
+						if !ok || schematic.Primary == nil || schematic.Primary.ID == "" {
+							return fmt.Errorf("factory schematic is missing from state")
+						}
+
+						if schematic.Primary.ID == images.DefaultInstallerImageSchematic {
+							return fmt.Errorf("test schematic must differ from the initial installer schematic")
+						}
+
+						return checkNodeSchematic("talos_machine.this", schematic.Primary.ID)(s)
+					},
+					resource.TestCheckResourceAttrSet("data.talos_cluster_health.this", "id"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // TestAccTalosMachine_drainWorkerUpgrade verifies that drain_on_upgrade = true works
 // on worker nodes when kubeconfig_wo is provided. Workers do not serve the Talos
 // kubeconfig API, so the provider must use the supplied kubeconfig to cordon and drain.
@@ -891,6 +948,14 @@ func installDiskPatch(talosVersion, image string) string {
 }
 
 func testAccTalosMachineConfig(rName, imageUrl, imageTag, isoVersion string) string {
+	return testAccTalosMachineConfigWithInstallImage(rName, imageUrl, imageTag, isoVersion, true)
+}
+
+func testAccTalosMachineConfigWithoutInstallImage(rName, imageUrl, imageTag, isoVersion string) string {
+	return testAccTalosMachineConfigWithInstallImage(rName, imageUrl, imageTag, isoVersion, false)
+}
+
+func testAccTalosMachineConfigWithInstallImage(rName, imageUrl, imageTag, isoVersion string, includeInstallImage bool) string {
 	cpuMode := cpuModeDefault
 	if os.Getenv("CI") != "" {
 		cpuMode = cpuModeCI
@@ -900,6 +965,11 @@ func testAccTalosMachineConfig(rName, imageUrl, imageTag, isoVersion string) str
 		"https://github.com/siderolabs/talos/releases/download/%s/metal-amd64.iso",
 		isoVersion,
 	)
+
+	configPatch := installDiskPatch(imageTag, "")
+	if includeInstallImage {
+		configPatch = installDiskPatch(imageTag, fmt.Sprintf("%s:%s", imageUrl, isoVersion))
+	}
 
 	return fmt.Sprintf(`
 resource "talos_machine_secrets" "this" {}
@@ -1009,8 +1079,7 @@ data "talos_cluster_health" "this" {
     read = "25m"
   }
 }
-`, rName, cpuMode, isoURL, imageUrl, imageTag, isoVersion,
-		installDiskPatch(imageTag, fmt.Sprintf("%s:%s", imageUrl, isoVersion)))
+`, rName, cpuMode, isoURL, imageUrl, imageTag, isoVersion, configPatch)
 }
 
 // testAccTalosMachineConfigWithWriteOnlyAttrs uses ephemeral talos_machine_secrets and
@@ -1916,7 +1985,7 @@ func TestNodeRequiresReplace(t *testing.T) {
 // TestDefaultTimeoutsSufficientForWorstCase verifies that the default Create and
 // Update timeouts cover the worst-case internal retry budgets:
 //
-//	Create: must exceed 20 m (10 m apply + 10 m wait-for-node)
+//	Create: must exceed 35 m (10 m apply + 10 m wait-for-node + 15 m reboot)
 //	Update: must exceed 80 m (10+10+60 m with legacy upgrade)
 func TestDefaultTimeoutsSufficientForWorstCase(t *testing.T) {
 	t.Parallel()
@@ -1924,6 +1993,7 @@ func TestDefaultTimeoutsSufficientForWorstCase(t *testing.T) {
 	const (
 		applyRetryBudget    = 10 * time.Minute
 		waitNodeBudget      = 10 * time.Minute
+		rebootBudget        = 15 * time.Minute
 		legacyUpgradeBudget = 60 * time.Minute
 	)
 
@@ -1932,7 +2002,7 @@ func TestDefaultTimeoutsSufficientForWorstCase(t *testing.T) {
 	defaultCreate := talos.DefaultCreateTimeout
 	defaultUpdate := talos.DefaultUpdateTimeout
 
-	worstCaseCreate := applyRetryBudget + waitNodeBudget                       // 20 m
+	worstCaseCreate := applyRetryBudget + waitNodeBudget + rebootBudget        // 35 m
 	worstCaseUpdate := applyRetryBudget + waitNodeBudget + legacyUpgradeBudget // 80 m
 
 	if defaultCreate < worstCaseCreate {


### PR DESCRIPTION
## Summary

- detect the active Image Factory schematic when talos_machine is created
- upgrade when the requested installer has the same Talos version but a different schematic
- preserve version-only behavior for non-Factory installer images
- cover custom registries, secure-boot installer references, and the create-time regression

## Testing

- go vet ./...
- go test ./...
- go test -race ./pkg/talos
- verified against an OpenStack cluster booted from a base image at the requested Talos version

Fixes #395