### PR TITLE
fix(talos_cluster): surface the actual health-check failure, not just the timeout

### DIFF
--- a/pkg/talos/talos_cluster_health_data_source.go
+++ b/pkg/talos/talos_cluster_health_data_source.go
@@ -81,9 +81,16 @@ func (c *clusterNodes) NodesByType(t machine.Type) []cluster.NodeInfo {
 	return c.nodesByType[t]
 }
 
+// reporter keeps one status line per distinct check, updating that line in place
+// as the check's state or last error changes, as long as each check in the list
+// has a stable, unique conditions.Condition.String(). For every check.ClusterCheck
+// in this package (all conditions.PollingCondition with a fixed description),
+// that holds, so the line count stays bounded by the number of checks being run
+// regardless of how many times a check is polled before it succeeds or the
+// overall wait times out.
 type reporter struct {
-	lastLine string
-	s        strings.Builder
+	lastCondition string
+	lines         []string
 }
 
 func newReporter() *reporter {
@@ -92,15 +99,24 @@ func newReporter() *reporter {
 
 // Update implements the conditions.Reporter interface.
 func (r *reporter) Update(condition conditions.Condition) {
-	if condition.String() != r.lastLine {
-		fmt.Fprintf(&r.s, "waiting for %s\n", condition.String())
-		r.lastLine = condition.String()
+	name := condition.String()
+	line := conditions.StatusLine(condition)
+
+	if name != r.lastCondition {
+		r.lines = append(r.lines, line)
+		r.lastCondition = name
+
+		return
+	}
+
+	if len(r.lines) > 0 {
+		r.lines[len(r.lines)-1] = line
 	}
 }
 
-// String returns the string representation of the reporter.
+// String returns the recorded status lines, one per check.
 func (r *reporter) String() string {
-	return r.s.String()
+	return strings.Join(r.lines, "\n")
 }
 
 // NewTalosClusterHealthDataSource implements the datasource.DataSource interface.
@@ -261,7 +277,7 @@ func (d *talosClusterHealthDataSource) Read(ctx context.Context, req datasource.
 	checkCtx, checkCtxCancel := context.WithTimeout(ctx, readTimeout)
 	defer checkCtxCancel()
 
-	reporter := newReporter()
+	progress := newReporter()
 
 	checks := check.PreBootSequenceChecks()
 
@@ -269,8 +285,11 @@ func (d *talosClusterHealthDataSource) Read(ctx context.Context, req datasource.
 		checks = check.DefaultClusterChecks()
 	}
 
-	if err := check.Wait(checkCtx, &clusterState, checks, reporter); err != nil {
-		resp.Diagnostics.AddWarning("failed checks", reporter.String())
+	if err := check.Wait(checkCtx, &clusterState, checks, progress); err != nil {
+		if s := progress.String(); s != "" {
+			resp.Diagnostics.AddWarning("failed checks", s)
+		}
+
 		resp.Diagnostics.AddError("cluster health check failed", err.Error())
 
 		return

--- a/pkg/talos/talos_cluster_health_ephemeral_resource.go
+++ b/pkg/talos/talos_cluster_health_ephemeral_resource.go
@@ -7,7 +7,6 @@ package talos
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -17,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/siderolabs/talos/pkg/cluster"
 	"github.com/siderolabs/talos/pkg/cluster/check"
-	"github.com/siderolabs/talos/pkg/conditions"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 )
 
@@ -32,28 +30,6 @@ type talosClusterHealthEphemeralResourceModel struct {
 	WorkerNodes          types.List          `tfsdk:"worker_nodes"`
 	Timeout              types.String        `tfsdk:"timeout"`
 	SkipKubernetesChecks types.Bool          `tfsdk:"skip_kubernetes_checks"`
-}
-
-type healthReporter struct {
-	lastLine string
-	s        strings.Builder
-}
-
-func newHealthReporter() *healthReporter {
-	return &healthReporter{}
-}
-
-// Update implements the conditions.Reporter interface.
-func (r *healthReporter) Update(condition conditions.Condition) {
-	if condition.String() != r.lastLine {
-		fmt.Fprintf(&r.s, "waiting for %s\n", condition.String())
-		r.lastLine = condition.String()
-	}
-}
-
-// String returns the string representation of the reporter.
-func (r *healthReporter) String() string {
-	return r.s.String()
 }
 
 // NewTalosClusterHealthEphemeralResource implements the ephemeral.EphemeralResource interface.
@@ -218,7 +194,7 @@ func (r *talosClusterHealthEphemeralResource) Open(ctx context.Context, req ephe
 	checkCtx, checkCtxCancel := context.WithTimeout(ctx, timeout)
 	defer checkCtxCancel()
 
-	reporter := newHealthReporter()
+	progress := newReporter()
 
 	checks := check.PreBootSequenceChecks()
 
@@ -226,8 +202,11 @@ func (r *talosClusterHealthEphemeralResource) Open(ctx context.Context, req ephe
 		checks = check.DefaultClusterChecks()
 	}
 
-	if err := check.Wait(checkCtx, &clusterState, checks, reporter); err != nil {
-		resp.Diagnostics.AddWarning("failed checks", reporter.String())
+	if err := check.Wait(checkCtx, &clusterState, checks, progress); err != nil {
+		if s := progress.String(); s != "" {
+			resp.Diagnostics.AddWarning("failed checks", s)
+		}
+
 		resp.Diagnostics.AddError("cluster health check failed", err.Error())
 
 		return

--- a/pkg/talos/talos_cluster_resource.go
+++ b/pkg/talos/talos_cluster_resource.go
@@ -295,7 +295,13 @@ func (r *talosClusterResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	if err = talosClusterWaitForK8s(ctxDeadline, endpoint, controlPlaneNodes, talosConfig); err != nil {
+	clusterReporter := newReporter()
+
+	if err = talosClusterWaitForK8s(ctxDeadline, endpoint, controlPlaneNodes, talosConfig, clusterReporter); err != nil {
+		if progress := clusterReporter.String(); progress != "" {
+			resp.Diagnostics.AddWarning("failed checks", progress)
+		}
+
 		resp.Diagnostics.AddError("error waiting for cluster health", err.Error())
 
 		return
@@ -408,7 +414,7 @@ func talosClusterBootstrap(ctx context.Context, endpoint, node string, talosConf
 }
 
 // talosClusterWaitForK8s waits for the cluster to pass all default health checks.
-func talosClusterWaitForK8s(ctx context.Context, endpoint string, controlPlaneNodes []string, talosConfig *clientconfig.Config) error {
+func talosClusterWaitForK8s(ctx context.Context, endpoint string, controlPlaneNodes []string, talosConfig *clientconfig.Config, progress *reporter) error {
 	c, err := client.New(ctx, client.WithConfig(talosConfig), client.WithEndpoints(endpoint))
 	if err != nil {
 		return err
@@ -434,7 +440,7 @@ func talosClusterWaitForK8s(ctx context.Context, endpoint string, controlPlaneNo
 		Info:           nodeInfos,
 	}
 
-	return check.Wait(ctx, &clusterState, check.PreBootSequenceChecks(), newReporter())
+	return check.Wait(ctx, &clusterState, check.PreBootSequenceChecks(), progress)
 }
 
 // talosClusterUpgradeKubernetes runs a rolling Kubernetes upgrade via the talos cluster package.

--- a/pkg/talos/talos_cluster_resource_internal_test.go
+++ b/pkg/talos/talos_cluster_resource_internal_test.go
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/siderolabs/talos/pkg/conditions"
+)
+
+// TestReporterCapturesLastAssertionError is the red-phase test for
+// https://github.com/siderolabs/terraform-provider-talos/issues/400: when
+// talos_cluster's health check times out, the user only ever sees "context
+// deadline exceeded" with no indication of which check failed or why (e.g. that
+// etcd gained members outside of the declared control_plane_nodes). The
+// underlying conditions.PollingCondition discards its last assertion error on
+// timeout, so the reporter is the only place that error can be recovered from.
+//
+// reporter.Update currently records condition.String() (just the check's
+// description), not conditions.StatusLine(condition) (description plus last
+// error), so the assertion error never reaches reporter.String() either.
+func TestReporterCapturesLastAssertionError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New(`etcd member ips ["10.0.0.2"] are not subset of control plane node ips ["10.0.0.1"]`)
+
+	condition := conditions.PollingCondition(
+		"etcd members to be control plane nodes",
+		func(context.Context) error { return wantErr },
+		5*time.Millisecond,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	condition.Wait(ctx) //nolint:errcheck // exercising the timeout path; the error is ctx.Err(), not wantErr
+
+	r := newReporter()
+	r.Update(condition)
+
+	if !strings.Contains(r.String(), wantErr.Error()) {
+		t.Fatalf("reporter lost the assertion error; want it to contain %q, got:\n%s", wantErr.Error(), r.String())
+	}
+}
+
+// TestReporterBoundsLineGrowthPerCheck guards against a regression in the fix
+// above: recording conditions.StatusLine(condition) instead of a static
+// description means the recorded line changes every time a check's last error
+// changes, not just when the check itself changes. A health check can poll every
+// 100ms for up to 30 minutes, so if reporter.Update naively appended on every
+// distinct StatusLine, one flaky check could produce thousands of lines. The
+// reporter must keep exactly one line per check, updated in place.
+func TestReporterBoundsLineGrowthPerCheck(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+
+	condition := conditions.PollingCondition(
+		"etcd members to be control plane nodes",
+		func(context.Context) error {
+			calls++
+
+			return fmt.Errorf("attempt %d: members not consistent", calls)
+		},
+		time.Millisecond,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	waitDone := make(chan struct{})
+
+	go func() {
+		defer close(waitDone)
+
+		condition.Wait(ctx) //nolint:errcheck // exercising the timeout path
+	}()
+
+	r := newReporter()
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+loop:
+	for {
+		select {
+		case <-waitDone:
+			break loop
+		case <-ticker.C:
+			r.Update(condition)
+		}
+	}
+
+	r.Update(condition)
+
+	if lines := strings.Split(r.String(), "\n"); len(lines) != 1 {
+		t.Fatalf("expected exactly one line for a single check polled repeatedly with a changing error, got %d:\n%s",
+			len(lines), r.String())
+	}
+}


### PR DESCRIPTION
## Summary

`talos_cluster`'s health check discarded all diagnostic detail on failure. `conditions.PollingCondition.Wait` returns bare `ctx.Err()` on timeout, and `talosClusterWaitForK8s` built its own reporter internally and never read it, so a failing health check surfaced only as `context deadline exceeded` — no indication of which check failed or why.

Related to #400: one common trigger is `control_plane_nodes` defaulting to `[node]`. Once the other control plane nodes join etcd, `EtcdControlPlaneNodesAssertion` fails every 5s because their IPs aren't in the declared set, but that reason was completely invisible — the user just saw a timeout.

**This does not remove the requirement to set `control_plane_nodes` for HA clusters** — that's the actual ask in #400 (auto-discovering control plane nodes instead of requiring a hand-maintained list), which is a separate, larger design question. This PR only makes the existing failure mode diagnosable: instead of a bare timeout, the error now includes the specific check and its last assertion error, e.g. `etcd members to be control plane nodes: etcd member ips [...] are not subset of control plane node ips [...]`.

## Changes

- `reporter.Update` now records `conditions.StatusLine(condition)` instead of bare `condition.String()`, capturing each check's last assertion error instead of just its name. It keeps exactly one line per check, updated in place, rather than appending — a check whose error text varies between 100ms polls over a multi-minute timeout can't make the report grow unbounded.
- The ephemeral resource's duplicate `healthReporter` type is removed; both `talos_cluster_health_data_source.go` and `talos_cluster_health_ephemeral_resource.go` now share the one `reporter` type.
- `talosClusterWaitForK8s` takes the reporter as a parameter instead of an internal, discarded one.
- `talos_cluster_resource.go`'s `Create()` surfaces the reporter's output via `AddWarning` on failure, matching the pattern `talos_cluster_health` already used — guarded so it doesn't add a blank warning if the failure happens before any check ran. The same guard is now applied to the data source and ephemeral resource for consistency.

## Test plan

- [x] `TestReporterCapturesLastAssertionError`: red/green test proving the reporter previously discarded the assertion error and now retains it.
- [x] `TestReporterBoundsLineGrowthPerCheck`: proves a single check polled repeatedly with a changing error still produces exactly one line, not one per poll.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/talos/...`
- [x] `go test ./pkg/talos/...` (full unit suite, plus `-race -count=10` on the new tests)