### PR TITLE
fix(talos_machine): stop corrupting digest-pinned image references

### DIFF
--- a/pkg/talos/config_hash.go
+++ b/pkg/talos/config_hash.go
@@ -198,7 +198,16 @@ func stripTagAtYAMLPath(m map[string]any, keys ...string) {
 //	"ghcr.io/siderolabs/kubelet:v1.35.4"      → "ghcr.io/siderolabs/kubelet"
 //	"my-reg.example.com:5000/kubelet:v1.35.4"  → "my-reg.example.com:5000/kubelet"
 //	"ghcr.io/siderolabs/kubelet"               → "ghcr.io/siderolabs/kubelet"
+//	"ghcr.io/siderolabs/kubelet@sha256:<hex>"  → "ghcr.io/siderolabs/kubelet@sha256:<hex>"
+//
+// Digest-pinned references are returned unchanged: unlike a tag, the digest is
+// the content identity itself, not a separately-bumped version label, so a
+// digest change must still register as a hash change.
 func stripImageTag(image string) string {
+	if isDigestPinnedImage(image) {
+		return image
+	}
+
 	i := strings.LastIndex(image, ":")
 	if i < 0 {
 		return image

--- a/pkg/talos/config_hash_internal_test.go
+++ b/pkg/talos/config_hash_internal_test.go
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+import "testing"
+
+// TestStripImageTag is the red-phase test for the digest-truncation defect
+// stripImageTag shared with replaceImageTag (issue #393): for a digest-pinned
+// reference, stripping everything after the last ':' also eats into the
+// "sha256:<hex>" digest, collapsing every digest down to the same
+// "repo@sha256" string. With ignore_kubernetes_upgrade_drift = true, that made
+// K8sManagedConfigHash blind to real changes to a pinned Kubernetes component
+// image.
+func TestStripImageTag(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		image string
+		want  string
+	}{
+		"tag reference": {
+			image: "ghcr.io/siderolabs/kubelet:v1.35.4",
+			want:  "ghcr.io/siderolabs/kubelet",
+		},
+		"no tag": {
+			image: "ghcr.io/siderolabs/kubelet",
+			want:  "ghcr.io/siderolabs/kubelet",
+		},
+		"registry host:port with a tag": {
+			image: "my-reg.example.com:5000/kubelet:v1.35.4",
+			want:  "my-reg.example.com:5000/kubelet",
+		},
+		"registry host:port with no tag": {
+			image: "my-reg.example.com:5000/kubelet",
+			want:  "my-reg.example.com:5000/kubelet",
+		},
+		"digest reference is left untouched": {
+			image: "ghcr.io/siderolabs/kubelet@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			want:  "ghcr.io/siderolabs/kubelet@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := stripImageTag(test.image); got != test.want {
+				t.Fatalf("stripImageTag(%q) = %q, want %q", test.image, got, test.want)
+			}
+		})
+	}
+}
+
+// TestStripImageTagDistinguishesDigests proves two different digest-pinned
+// references stay distinguishable after stripping, which is what
+// K8sManagedConfigHash relies on to detect a real change to a pinned image.
+// Before the fix, both collapsed to the identical "repo@sha256" string.
+func TestStripImageTagDistinguishesDigests(t *testing.T) {
+	t.Parallel()
+
+	const repo = "ghcr.io/siderolabs/kubelet@sha256:"
+
+	a := stripImageTag(repo + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	b := stripImageTag(repo + "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	if a == b {
+		t.Fatalf("stripImageTag collapsed two different digests to the same value: %q", a)
+	}
+}

--- a/pkg/talos/talos_machine_resource.go
+++ b/pkg/talos/talos_machine_resource.go
@@ -871,7 +871,7 @@ func talosMachineRunningVersion(ctx context.Context, endpoint, node string, talo
 			}
 
 			for _, msg := range versionResp.Messages {
-				runningImage = replaceImageTag(desiredImage, msg.Version.Tag)
+				runningImage = talosMachineReconcileRunningImage(desiredImage, msg.Version.Tag)
 
 				break
 			}
@@ -1159,12 +1159,36 @@ func talosMachineUpgradeLegacy(ctx context.Context, endpoint, node string, talos
 
 // replaceImageTag replaces the tag portion of an image reference.
 // "ghcr.io/siderolabs/installer:v1.8.0" + "v1.9.0" → "ghcr.io/siderolabs/installer:v1.9.0".
+// Digest-pinned references ("repo@sha256:<hex>") already fully identify the image and
+// have no tag component to replace, so they are returned unchanged — otherwise the
+// last ':' found belongs to the digest's "sha256:" prefix, corrupting it.
 func replaceImageTag(imageRef, newTag string) string {
-	if idx := strings.LastIndex(imageRef, ":"); idx != -1 {
+	if isDigestPinnedImage(imageRef) {
+		return imageRef
+	}
+
+	// The tag separator is only the last ':' if it comes after the last '/' —
+	// otherwise it's a registry host:port, e.g. "registry.example.com:5000/repo".
+	if idx := strings.LastIndex(imageRef, ":"); idx > strings.LastIndex(imageRef, "/") {
 		return imageRef[:idx+1] + newTag
 	}
 
 	return imageRef + ":" + newTag
+}
+
+// talosMachineReconcileRunningImage returns the image reference to compare against
+// desiredImage when deciding whether a node already runs the desired install, given
+// the version tag reported by that node. Digest-pinned images have no tag component
+// to compare against the reported version, so there is no reliable way to tell
+// whether the node already runs the desired image. Returning "" guarantees it never
+// matches desiredImage, so the caller installs it rather than silently skipping a
+// node that was never actually reconciled.
+func talosMachineReconcileRunningImage(desiredImage, reportedTag string) string {
+	if isDigestPinnedImage(desiredImage) {
+		return ""
+	}
+
+	return replaceImageTag(desiredImage, reportedTag)
 }
 
 // resolveTalosMachineClientConfig builds the Talos client config from either the

--- a/pkg/talos/talos_machine_resource_internal_test.go
+++ b/pkg/talos/talos_machine_resource_internal_test.go
@@ -16,6 +16,10 @@ import (
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 )
 
+// testDigest is a fixture SHA-256 digest reused by tests covering digest-pinned
+// image references.
+const testDigest = "sha256:b9a485250c4d1a3f6d3b1c1b0a1f6a1c1e1a1b1c1d1e1f1a1b1c1d1e1f1a1b1c"
+
 // TestLegacyUpgrade_ImmediateRPCError_AbortsPollEarly calls the real
 // talosMachineUpgradeLegacy with a mock op that returns an error immediately.
 // It verifies the function returns well within the 5-second context deadline
@@ -49,5 +53,97 @@ func TestLegacyUpgrade_ImmediateRPCError_AbortsPollEarly(t *testing.T) {
 	// path. Its presence proves the goroutine error reached the poll loop.
 	if !strings.Contains(err.Error(), "upgrade RPC failed:") {
 		t.Fatalf("expected 'upgrade RPC failed:' in error message, got: %v", err)
+	}
+}
+
+// TestReplaceImageTag is the red-phase test for
+// https://github.com/siderolabs/terraform-provider-talos/issues/393: for a
+// digest-pinned reference, replacing everything after the last ':' also eats
+// into the "sha256:<hex>" digest, producing a corrupted reference such as
+// "repo@sha256:v1.13.9". That corrupted value gets written back into
+// talos_machine's state on every Read (and compared against the desired image
+// on every Update), so digest-pinned images never reach a stable plan.
+func TestReplaceImageTag(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		imageRef string
+		newTag   string
+		want     string
+	}{
+		"tag reference": {
+			imageRef: "ghcr.io/siderolabs/installer:v1.13.0",
+			newTag:   "v1.13.9",
+			want:     "ghcr.io/siderolabs/installer:v1.13.9",
+		},
+		"no tag": {
+			imageRef: "ghcr.io/siderolabs/installer",
+			newTag:   "v1.13.9",
+			want:     "ghcr.io/siderolabs/installer:v1.13.9",
+		},
+		"digest reference is left untouched": {
+			imageRef: "ghcr.io/siderolabs/installer@" + testDigest,
+			newTag:   "v1.13.9",
+			want:     "ghcr.io/siderolabs/installer@" + testDigest,
+		},
+		"registry host:port with no tag": {
+			imageRef: "registry.example.com:5000/siderolabs/installer",
+			newTag:   "v1.13.9",
+			want:     "registry.example.com:5000/siderolabs/installer:v1.13.9",
+		},
+		"registry host:port with a tag": {
+			imageRef: "registry.example.com:5000/siderolabs/installer:v1.13.0",
+			newTag:   "v1.13.9",
+			want:     "registry.example.com:5000/siderolabs/installer:v1.13.9",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := replaceImageTag(test.imageRef, test.newTag); got != test.want {
+				t.Fatalf("replaceImageTag(%q, %q) = %q, want %q", test.imageRef, test.newTag, got, test.want)
+			}
+		})
+	}
+}
+
+// TestTalosMachineReconcileRunningImage is the red-phase test for the Create-time
+// regression the naive digest fix introduced: if a digest-pinned desiredImage were
+// compared using replaceImageTag directly, it would always equal desiredImage
+// itself, so talosMachineUpgradeIfNeeded would conclude the node already runs the
+// desired image and skip installing it — even on a freshly provisioned node that
+// has never run it. talosMachineReconcileRunningImage must return "" for digest
+// pins so the caller always installs instead.
+func TestTalosMachineReconcileRunningImage(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		desiredImage string
+		reportedTag  string
+		want         string
+	}{
+		"tag reference reflects the reported version": {
+			desiredImage: "ghcr.io/siderolabs/installer:v1.13.0",
+			reportedTag:  "v1.13.9",
+			want:         "ghcr.io/siderolabs/installer:v1.13.9",
+		},
+		"digest reference never matches, forcing install": {
+			desiredImage: "ghcr.io/siderolabs/installer@" + testDigest,
+			reportedTag:  "v1.13.9",
+			want:         "",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := talosMachineReconcileRunningImage(test.desiredImage, test.reportedTag); got != test.want {
+				t.Fatalf("talosMachineReconcileRunningImage(%q, %q) = %q, want %q",
+					test.desiredImage, test.reportedTag, got, test.want)
+			}
+		})
 	}
 }

--- a/pkg/talos/util.go
+++ b/pkg/talos/util.go
@@ -800,3 +800,11 @@ func (v ipAddressValidator) Description(_ context.Context) string {
 func (v ipAddressValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
+
+// isDigestPinnedImage reports whether an OCI image reference is pinned by digest
+// (e.g. "repo@sha256:<hex>") rather than by tag. Digest references fully identify
+// the image on their own, so callers should not try to extract or replace a tag
+// component from one.
+func isDigestPinnedImage(imageRef string) bool {
+	return strings.Contains(imageRef, "@")
+}


### PR DESCRIPTION
## Summary

`replaceImageTag` naively replaced everything after the last `:`, which for a digest reference (`repo@sha256:<hex>`) lands inside the digest itself, corrupting it to `repo@sha256:<tag>` (#393). `Read()` then wrote that corrupted value back into state on every refresh, so digest-pinned images never reached a stable plan.

## Changes

- Digest references now pass through `replaceImageTag` unchanged: they already fully identify the image, so there's no tag component to substitute.
- `talosMachineRunningVersion` (the Create-time "is this node already running the desired image" check) needed the opposite treatment in the same spot: naively leaving a digest-pinned `desiredImage` unchanged there would make it always equal itself and skip the install entirely, even on a node that has never run it. It now returns `""` for digest-pinned images instead — guaranteed to mismatch, so the caller always installs rather than silently skipping reconciliation it can't actually verify.
- `stripImageTag` (`config_hash.go`) had the identical defect for a different purpose: it strips a version tag from Kubernetes component images before hashing, so `ignore_kubernetes_upgrade_drift` can ignore tag-only bumps. For a digest-pinned component image it collapsed every digest down to the same `repo@sha256` string, making a real change to a pinned image invisible to the hash. It now also passes digest references through unchanged.
- Both call sites share one `isDigestPinnedImage` helper instead of duplicating the `@` check.
- Also fixed `replaceImageTag` misreading a registry host:port (e.g. `registry.example.com:5000/repo` with no tag) as a tag separator, dropping the rest of the path.

## Test plan

- [x] `TestReplaceImageTag`, `TestTalosMachineReconcileRunningImage`, `TestStripImageTag`, `TestStripImageTagDistinguishesDigests`: red/green unit tests proving the corruption and the fix, including a repro of the exact reported case.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/talos/...`
- [x] `go test ./pkg/talos/...` (full unit suite, plus `-race -count=5` on the changed functions)